### PR TITLE
feat: implement Azure built-in role inheritance for role assignments

### DIFF
--- a/internal/providers/azure/main.go
+++ b/internal/providers/azure/main.go
@@ -23,6 +23,8 @@ const (
 	GetRoleDefinitionActivityName         = "GetRoleDefinition"
 	DeleteRoleAssignmentActivityName      = "DeleteRoleAssignment"
 	DeleteRoleDefinitionActivityName      = "DeleteRoleDefinition"
+	AssignBuiltInRolesActivityName        = "AssignBuiltInRoles"
+	RevokeBuiltInRolesActivityName        = "RevokeBuiltInRoles"
 )
 
 // UseLatestVersion is the version string passed to Azure Key Vault APIs when the

--- a/internal/providers/azure/rbac.go
+++ b/internal/providers/azure/rbac.go
@@ -15,6 +15,30 @@ import (
 
 const PrincipalIdentifierMetadataKey = "principal_id"
 const RoleDefinitionIdentifierMetadataKey = "role_definition_id"
+const BuiltInRoleDefinitionIdsMetadataKey = "built_in_role_definition_ids"
+
+// extractStringSlice safely extracts a []string from a map[string]any value.
+// After JSON round-trip through Temporal, []string is deserialized as []interface{},
+// so both types are handled.
+func extractStringSlice(m map[string]any, key string) []string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case []string:
+		return val
+	case []interface{}:
+		result := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	}
+	return nil
+}
 
 // Authorize grants access for a user to a role.
 //
@@ -69,12 +93,26 @@ func (p *azureProvider) AuthorizeRole(
 		return nil, fmt.Errorf("failed to create role assignment: %w", err)
 	}
 
+	// Assign inherited built-in Azure roles (e.g. "Reader" from role.Inherits)
+	builtInRoleDefIDs := make([]string, 0, len(role.Inherits))
+	for _, inheritedRoleName := range role.Inherits {
+		builtInDef, err := p.getRoleDefinition(localCtx, inheritedRoleName)
+		if err != nil {
+			return nil, fmt.Errorf("inherited Azure role '%s' not found: %w", inheritedRoleName, err)
+		}
+		if _, err = p.createRoleAssignment(localCtx, user, *builtInDef.ID); err != nil {
+			return nil, fmt.Errorf("failed to assign inherited role '%s': %w", inheritedRoleName, err)
+		}
+		builtInRoleDefIDs = append(builtInRoleDefIDs, *builtInDef.ID)
+	}
+
 	return &models.AuthorizeRoleResponse{
 		UserId: user.Email,
 		Roles:  []string{roleName},
 		Metadata: map[string]any{
 			PrincipalIdentifierMetadataKey:      principalID,
 			RoleDefinitionIdentifierMetadataKey: *existingRole.ID,
+			BuiltInRoleDefinitionIdsMetadataKey: builtInRoleDefIDs,
 		},
 	}, nil
 }
@@ -136,6 +174,14 @@ func (p *azureProvider) RevokeRole(
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to delete role assignment: %w", err)
+		}
+
+		// Revoke inherited built-in role assignments
+		builtInDefIDs := extractStringSlice(req.AuthorizeRoleResponse.Metadata, BuiltInRoleDefinitionIdsMetadataKey)
+		for _, builtInDefID := range builtInDefIDs {
+			if err := p.deleteRoleAssignment(localCtx, user, builtInDefID, principalID); err != nil {
+				return nil, fmt.Errorf("failed to revoke inherited role assignment '%s': %w", builtInDefID, err)
+			}
 		}
 
 	} else {
@@ -210,12 +256,28 @@ func (p *azureProvider) authorizeRoleTemporal(
 		return nil, fmt.Errorf("CreateRoleAssignment activity failed: %w", err)
 	}
 
+	// Step 3 — Assign inherited built-in Azure roles (e.g. "Reader" from role.Inherits)
+	var builtInResp AssignBuiltInRolesResponse
+	if len(role.Inherits) > 0 {
+		if err := workflow.ExecuteActivity(
+			wfCtx,
+			models.CreateTemporalProviderWorkflowName(identifier, AssignBuiltInRolesActivityName),
+			&AssignBuiltInRolesRequest{
+				User:      user,
+				RoleNames: role.Inherits,
+			},
+		).Get(wfCtx, &builtInResp); err != nil {
+			return nil, fmt.Errorf("AssignBuiltInRoles activity failed: %w", err)
+		}
+	}
+
 	return &models.AuthorizeRoleResponse{
 		UserId: user.Email,
 		Roles:  []string{roleName},
 		Metadata: map[string]any{
 			PrincipalIdentifierMetadataKey:      assignResp.PrincipalID,
 			RoleDefinitionIdentifierMetadataKey: roleDefResp.RoleDefinitionID,
+			BuiltInRoleDefinitionIdsMetadataKey: builtInResp.RoleDefinitionIDs,
 		},
 	}, nil
 }
@@ -287,7 +349,23 @@ func (p *azureProvider) revokeRoleTemporal(
 		return nil, fmt.Errorf("DeleteRoleAssignment activity failed: %w", err)
 	}
 
-	// Step 3 — For composite roles, delete the role definition.
+	// Step 3 — Revoke inherited built-in role assignments (if any were stored)
+	builtInDefIDs := extractStringSlice(req.AuthorizeRoleResponse.Metadata, BuiltInRoleDefinitionIdsMetadataKey)
+	if len(builtInDefIDs) > 0 {
+		if err := workflow.ExecuteActivity(
+			wfCtx,
+			models.CreateTemporalProviderWorkflowName(identifier, RevokeBuiltInRolesActivityName),
+			&RevokeBuiltInRolesRequest{
+				User:              user,
+				PrincipalID:       principalID,
+				RoleDefinitionIDs: builtInDefIDs,
+			},
+		).Get(wfCtx, nil); err != nil {
+			return nil, fmt.Errorf("RevokeBuiltInRoles activity failed: %w", err)
+		}
+	}
+
+	// Step 4 — For composite roles, delete the role definition.
 	if isComposite {
 		if err := workflow.ExecuteActivity(
 			wfCtx,

--- a/internal/providers/azure/rbac_activities.go
+++ b/internal/providers/azure/rbac_activities.go
@@ -58,6 +58,21 @@ type DeleteRoleDefinitionRequest struct {
 	RoleDefinitionID string `json:"role_definition_id"`
 }
 
+type AssignBuiltInRolesRequest struct {
+	User      *models.User `json:"user"`
+	RoleNames []string     `json:"role_names"`
+}
+
+type AssignBuiltInRolesResponse struct {
+	RoleDefinitionIDs []string `json:"role_definition_ids"`
+}
+
+type RevokeBuiltInRolesRequest struct {
+	User              *models.User `json:"user"`
+	PrincipalID       string       `json:"principal_id"`
+	RoleDefinitionIDs []string     `json:"role_definition_ids"`
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Activity implementations
 // ─────────────────────────────────────────────────────────────────────────────
@@ -162,6 +177,63 @@ func (a *azureProviderActivities) DeleteRoleDefinition(
 				Cause:          err,
 			},
 		)
+	}
+	return nil
+}
+
+// AssignBuiltInRoles looks up each inherited Azure role by name and creates a
+// direct role assignment for the user against each one. Returns the list of
+// role definition IDs that were assigned, which must be stored in
+// AuthorizeRoleResponse.Metadata for later revocation.
+func (a *azureProviderActivities) AssignBuiltInRoles(
+	ctx context.Context,
+	req *AssignBuiltInRolesRequest,
+) (*AssignBuiltInRolesResponse, error) {
+	roleDefinitionIDs := make([]string, 0, len(req.RoleNames))
+	for _, roleName := range req.RoleNames {
+		roleDef, err := a.provider.getRoleDefinition(ctx, roleName)
+		if err != nil {
+			return nil, temporal.NewApplicationErrorWithOptions(
+				fmt.Sprintf("inherited Azure role '%s' not found: %v", roleName, err),
+				"AzureBuiltInRoleNotFoundError",
+				temporal.ApplicationErrorOptions{
+					NextRetryDelay: 3 * time.Second,
+					Cause:          err,
+				},
+			)
+		}
+		if _, err = a.provider.createRoleAssignment(ctx, req.User, *roleDef.ID); err != nil {
+			return nil, temporal.NewApplicationErrorWithOptions(
+				fmt.Sprintf("failed to assign inherited role '%s' to user '%s': %v", roleName, req.User.Email, err),
+				"AzureBuiltInRoleAssignmentError",
+				temporal.ApplicationErrorOptions{
+					NextRetryDelay: 3 * time.Second,
+					Cause:          err,
+				},
+			)
+		}
+		roleDefinitionIDs = append(roleDefinitionIDs, *roleDef.ID)
+	}
+	return &AssignBuiltInRolesResponse{RoleDefinitionIDs: roleDefinitionIDs}, nil
+}
+
+// RevokeBuiltInRoles removes the direct role assignments for each inherited
+// built-in role that was assigned during authorization.
+func (a *azureProviderActivities) RevokeBuiltInRoles(
+	ctx context.Context,
+	req *RevokeBuiltInRolesRequest,
+) error {
+	for _, roleDefID := range req.RoleDefinitionIDs {
+		if err := a.provider.deleteRoleAssignment(ctx, req.User, roleDefID, req.PrincipalID); err != nil {
+			return temporal.NewApplicationErrorWithOptions(
+				fmt.Sprintf("failed to delete built-in role assignment '%s' for user '%s': %v", roleDefID, req.User.Email, err),
+				"AzureBuiltInRoleRevocationError",
+				temporal.ApplicationErrorOptions{
+					NextRetryDelay: 3 * time.Second,
+					Cause:          err,
+				},
+			)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- When a thand role specifies `inherits: [Reader]` (or any Azure built-in role name), the Azure provider now looks up each inherited role's Azure definition ID and creates a **direct role assignment** for the user against it
- Built-in role definition IDs are stored in `AuthorizeRoleResponse.Metadata` under `built_in_role_definition_ids` so they can be cleanly revoked
- On revocation, all inherited built-in role assignments are removed alongside the main custom role assignment

## Changes

**`internal/providers/azure/main.go`**
- Added `AssignBuiltInRolesActivityName` and `RevokeBuiltInRolesActivityName` constants

**`internal/providers/azure/rbac.go`**
- Added `BuiltInRoleDefinitionIdsMetadataKey` metadata constant
- Added `extractStringSlice` helper for safe `[]string` extraction from `map[string]any` after JSON round-trip
- Updated `AuthorizeRole` (sync) and `authorizeRoleTemporal` to assign inherited built-in roles
- Updated `RevokeRole` (sync) and `revokeRoleTemporal` to revoke inherited built-in role assignments

**`internal/providers/azure/rbac_activities.go`**
- Added `AssignBuiltInRoles` activity: resolves each inherited role name to an Azure definition ID and creates an assignment
- Added `RevokeBuiltInRoles` activity: deletes each stored built-in assignment by definition ID

## Backward compatibility

Existing authorizations without `built_in_role_definition_ids` in metadata will skip built-in revocation gracefully — `extractStringSlice` returns nil and the loop is skipped.

## Test plan

- [ ] All existing Azure provider tests pass (`go test ./internal/providers/azure/...`)
- [ ] All config tests pass (`go test ./internal/config/...`)
- [ ] Integration: elevate a user with a role that has `inherits: [Reader]` and confirm two role assignments appear in Azure — one for the custom role, one for built-in Reader
- [ ] Revoke and confirm both assignments are removed