### PR TITLE
[DNM] fix: avoid oversized generic oauth2 auth cookies

### DIFF
--- a/internal/providers/oauth2/sessions.go
+++ b/internal/providers/oauth2/sessions.go
@@ -99,16 +99,7 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 		}
 	}
 
-	idToken, _ := token.Extra("id_token").(string)
-
-	session := models.Session{
-		UUID:         uuid.New(),
-		User:         user,
-		Token:        idToken,
-		AccessToken:  token.AccessToken,
-		RefreshToken: token.RefreshToken,
-		Expiry:       token.Expiry,
-	}
+	session := buildAuthOnlySession(user, token)
 
 	// Log the identity information being added
 	// ONLY log in debug to avoid PII leakage
@@ -124,7 +115,24 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 		User:  user,
 	})
 
-	return &session, nil
+	return session, nil
+}
+
+func buildAuthOnlySession(user *models.User, token *oauth2.Token) *models.Session {
+	session := &models.Session{
+		UUID: uuid.New(),
+		User: user,
+	}
+
+	if token != nil {
+		session.Expiry = token.Expiry
+	}
+
+	// Generic oauth2 providers in this repo are used for browser authentication
+	// and identity discovery only. Persisting raw OAuth tokens in cookies can
+	// easily exceed browser size limits, while later generic oauth2 validation
+	// paths do not consume those token fields.
+	return session
 }
 
 // getUserInfoFromIDToken tries to extract user info from the ID token JWT claims.

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -1,0 +1,111 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/thand-io/agent/internal/models"
+)
+
+func TestCreateSessionOmitsOAuthTokens(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"email_verified": true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			t.Fatalf("unexpected token request path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "very-large-access-token",
+			"refresh_token": "very-large-refresh-token",
+			"id_token":      idToken,
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	cfg := models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      tokenServer.URL + "/auth",
+		"token_url":     tokenServer.URL + "/token",
+		"scopes":        []string{"openid", "profile", "email"},
+	}
+
+	provider := &oauth2Provider{}
+	err := provider.Initialize("oauth2-test", models.ProviderConfig{
+		Name:     "OAuth2 Test",
+		Provider: Oauth2ProviderName,
+		Enabled:  true,
+		Config:   &cfg,
+	})
+	if err != nil {
+		t.Fatalf("initialize provider: %v", err)
+	}
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session == nil {
+		t.Fatal("expected session")
+	}
+
+	if session.User == nil {
+		t.Fatal("expected user")
+	}
+
+	if session.User.Email != "user@example.com" {
+		t.Fatalf("expected user email to be preserved, got %q", session.User.Email)
+	}
+
+	if session.Expiry.IsZero() {
+		t.Fatal("expected expiry to be set")
+	}
+
+	if session.Token != "" {
+		t.Fatalf("expected id token to be omitted, got %q", session.Token)
+	}
+
+	if session.AccessToken != "" {
+		t.Fatalf("expected access token to be omitted, got %q", session.AccessToken)
+	}
+
+	if session.RefreshToken != "" {
+		t.Fatalf("expected refresh token to be omitted, got %q", session.RefreshToken)
+	}
+}
+
+func createTestIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	headerBytes, err := json.Marshal(map[string]any{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(headerBytes) +
+		"." + base64.RawURLEncoding.EncodeToString(payloadBytes) +
+		"."
+}

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/thand-io/agent/internal/models"
@@ -18,10 +19,16 @@ func TestCreateSessionOmitsOAuthTokens(t *testing.T) {
 		"name":           "Example User",
 		"email_verified": true,
 	})
+	var mu sync.Mutex
+	var unexpectedTokenPath string
 
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/token" {
-			t.Fatalf("unexpected token request path: %s", r.URL.Path)
+			mu.Lock()
+			unexpectedTokenPath = r.URL.Path
+			mu.Unlock()
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -61,6 +68,13 @@ func TestCreateSessionOmitsOAuthTokens(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("create session: %v", err)
+	}
+
+	mu.Lock()
+	gotUnexpectedTokenPath := unexpectedTokenPath
+	mu.Unlock()
+	if gotUnexpectedTokenPath != "" {
+		t.Fatalf("unexpected token request path: %s", gotUnexpectedTokenPath)
 	}
 
 	if session == nil {


### PR DESCRIPTION
## Summary

Generic `provider: oauth2` sessions were persisting raw OAuth token material into cookie-backed local sessions.
Large token payloads can overflow browser cookie limits and break auth callback completion.
This change keeps generic OAuth2 persisted sessions auth-only by storing user identity and expiry without persisting token strings.

## Reproduction

Observed with JumpCloud using generic OAuth2.
Specifically reproducible when JumpCloud **Access Token Format** is **JWT** rather than **Opaque**.
The underlying issue is still generic and can affect other OAuth2 providers that emit large token payloads.

## TDD proof

A new regression test was added first in isolation.
Pre-fix, the test failed because `CreateSession` persisted the `id_token`.
Post-fix, `go test ./internal/providers/oauth2` passes.

## Testing

- `go test ./internal/providers/oauth2`

## Follow-up manual verification

- restart the Thand server
- retry `/api/v1/auth/request/oauth2-jumpcloud`
- confirm the callback no longer fails with `failed to save auth cookie: securecookie: the value is too long: 4648`

## Notes

This will have to be revisited if we want to support `ValidateSession` or `RenewSession` but probably requires more changes anyway (cookie chunking, CSRF defense)