### PR TITLE
docs: align OAuth2 provider docs with the implemented schema

### DIFF
--- a/docs/configuration/providers/oauth2.google/index.md
+++ b/docs/configuration/providers/oauth2.google/index.md
@@ -8,23 +8,34 @@ grand_parent: Configuration
 
 # Google OAuth2 Provider
 
-The Google OAuth2 provider enables authentication with Google accounts using OAuth2.
+The Google OAuth2 provider enables authentication with Google accounts using Google's standard OAuth2 endpoints. Use this provider when you want Google sign-in without manually configuring `auth_url` and `token_url`.
 
 ## Capabilities
 
 - **Authentication**: Google account OAuth2 authentication
-- **Google Services**: Access to Google user profile and services
-- **OpenID Connect**: Support for OpenID Connect with Google
-- **Scope Management**: Configurable OAuth2 scopes
+- **Google User Info**: Fetches profile information from Google's OAuth2 userinfo API
+- **Built-In Endpoints**: Uses Google's OAuth2 authorization and token endpoints automatically
+- **Scope Management**: Configurable OAuth2 scopes with provider defaults
+
+## Prerequisites
+
+1. Create an OAuth 2.0 client in Google Cloud for a web application.
+2. Register the redirect URI that your agent uses for Google sign-in.
+3. Copy the generated client ID and client secret into the provider config.
 
 ## Configuration Options
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `client_id` | string | Yes | Google OAuth2 client ID |
-| `client_secret` | string | Yes | Google OAuth2 client secret |
-| `scopes` | array | No | OAuth2 scopes to request |
-| `hosted_domain` | string | No | Restrict to specific Google Workspace domain |
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `client_id` | string | Yes | - | Google OAuth2 client ID |
+| `client_secret` | string | Yes | - | Google OAuth2 client secret |
+| `scopes` | array | No | `["email", "profile"]` | Scopes to request during authorization |
+
+## Behavior Notes
+
+- The provider uses Google's built-in OAuth2 endpoints; you do not need to set `auth_url` or `token_url`.
+- If `scopes` is omitted, the provider defaults to `email` and `profile`.
+- This provider does not currently expose a `hosted_domain` or domain restriction setting in its config schema.
 
 ## Example Configuration
 
@@ -43,17 +54,15 @@ providers:
         - openid
         - profile
         - email
-      hosted_domain: your-company.com
 ```
 
 ### Getting Google OAuth2 Credentials
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
 2. Create or select a project
-3. Enable the Google+ API
-4. Go to Credentials → Create Credentials → OAuth 2.0 Client IDs
-5. Configure the OAuth consent screen
-6. Create OAuth2 credentials for a web application
-7. Add authorized redirect URIs
+3. Configure the OAuth consent screen
+4. Go to Credentials and create an OAuth 2.0 Client ID for a web application
+5. Add your agent's authorized redirect URI
+6. Copy the client ID and client secret into the provider configuration
 
 For detailed setup instructions, refer to the [Google OAuth2 documentation](https://developers.google.com/identity/protocols/oauth2/).

--- a/docs/configuration/providers/oauth2/index.md
+++ b/docs/configuration/providers/oauth2/index.md
@@ -8,28 +8,28 @@ grand_parent: Configuration
 
 # OAuth2 Provider
 
-The OAuth2 provider enables integration with any OAuth2-compliant service, providing generic authentication capabilities through the OAuth2 authorization framework.
+The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or OpenID Connect provider. Use it when you need to supply custom authorization and token endpoint URLs instead of relying on a built-in provider such as `oauth2.google`.
 
 ## Capabilities
 
-- **Authentication**: OAuth2 authorization code flow authentication
-- **Generic Integration**: Works with any OAuth2-compliant service
-- **Token Management**: Access token and refresh token handling
-- **Customizable Endpoints**: Configurable authorization and token endpoints
+- **Authentication**: Interactive OAuth2 authorization code flow
+- **Generic Integration**: Works with providers that expose standard authorization and token endpoints
+- **Identity Discovery**: Builds user identities from an ID token or a compatible `userinfo` endpoint
+- **Customizable Endpoints**: Lets you provide full authorization and token URLs directly
 
 ## Prerequisites
 
 ### OAuth2 Service Setup
 
-1. **OAuth2 Service**: Access to an OAuth2-compliant service
-2. **Application Registration**: Registered application with OAuth2 provider
-3. **Client Credentials**: Client ID and client secret from the OAuth2 provider
-4. **Redirect URI**: Configured redirect URI in the OAuth2 provider
+1. **OAuth2 Service**: Access to an OAuth2 or OpenID Connect provider
+2. **Application Registration**: Registered application with that provider
+3. **Client Credentials**: Client ID and client secret from the provider
+4. **Redirect URI**: A redirect URI registered for your agent login callback
 
 ### Required OAuth2 Configuration
 
-- **Authorization Endpoint**: OAuth2 authorization URL
-- **Token Endpoint**: OAuth2 token exchange URL
+- **Authorization Endpoint**: Full authorization URL
+- **Token Endpoint**: Full token exchange URL
 - **Client ID**: OAuth2 application client identifier
 - **Client Secret**: OAuth2 application client secret
 
@@ -37,17 +37,25 @@ The OAuth2 provider enables integration with any OAuth2-compliant service, provi
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `authority` | string | Yes | - | OAuth2 authority/base URL |
-| `client.id` | string | Yes | - | OAuth2 client ID |
-| `client.secret` | string | Yes | - | OAuth2 client secret |
-| `endpoints.auth` | string | No | `/auth` | Authorization endpoint path |
-| `endpoints.token` | string | No | `/token` | Token endpoint path |
-| `grant` | string | No | `authorization_code` | OAuth2 grant type |
-| `scopes` | array | No | `[]` | Requested OAuth2 scopes |
+| `client_id` | string | Yes | - | OAuth2 client ID |
+| `client_secret` | string | Yes | - | OAuth2 client secret |
+| `auth_url` | string | Yes* | - | Full authorization endpoint URL |
+| `token_url` | string | Yes* | - | Full token endpoint URL |
+| `redirect_url` | string | No | - | Default redirect URI if one is not supplied at login time |
+| `scopes` | array | No | `["openid"]` | Scopes requested during authorization |
+
+\* The schema accepts omitted values, but the generic provider does not supply defaults. In practice you should set both `auth_url` and `token_url`.
+
+## Behavior Notes
+
+- This provider is built around the OAuth2 authorization code flow used for browser login.
+- The provider always includes the `openid` scope during authorization if it is missing from the requested scope list.
+- User details are read from the returned `id_token` when present. If no ID token is returned, the provider tries a `userinfo` endpoint derived from `token_url` by replacing `/token` with `/userinfo`.
+- This provider does not perform OIDC discovery. You must configure the endpoint URLs explicitly.
 
 ## Example Configurations
 
-### Generic OAuth2 Service
+### Generic OAuth2 / OIDC Service
 
 ```yaml
 version: "1.0"
@@ -58,20 +66,18 @@ providers:
     provider: oauth2
     enabled: true
     config:
-      authority: https://oauth.example.com
-      client:
-        id: YOUR_CLIENT_ID
-        secret: YOUR_CLIENT_SECRET
-      endpoints:
-        auth: /oauth/authorize
-        token: /oauth/token
+      client_id: YOUR_CLIENT_ID
+      client_secret: YOUR_CLIENT_SECRET
+      auth_url: https://auth.example.com/oauth2/authorize
+      token_url: https://auth.example.com/oauth2/token
+      redirect_url: https://agent.example.com/auth/callback
       scopes:
         - openid
         - profile
         - email
 ```
 
-### Google OAuth2 (Alternative to oauth2.google)
+### Google via Generic OAuth2
 
 ```yaml
 version: "1.0"
@@ -82,17 +88,14 @@ providers:
     provider: oauth2
     enabled: true
     config:
-      authority: https://accounts.google.com/o/oauth2
-      client:
-        id: YOUR_GOOGLE_CLIENT_ID
-        secret: YOUR_GOOGLE_CLIENT_SECRET
-      endpoints:
-        auth: /auth
-        token: /token
+      client_id: YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com
+      client_secret: YOUR_GOOGLE_CLIENT_SECRET
+      auth_url: https://accounts.google.com/o/oauth2/v2/auth
+      token_url: https://oauth2.googleapis.com/token
       scopes:
         - openid
         - profile
         - email
 ```
 
-For detailed OAuth2 setup instructions, refer to your specific OAuth2 provider's documentation.
+If you only need Google sign-in, prefer `oauth2.google`, which already includes Google's endpoint configuration.

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ examples/
 
 ### Authentication & Identity
 
+- **[OAuth2](providers/oauth.example.yaml)** - Generic OAuth2 or OpenID Connect authentication
 - **[Google OAuth2](providers/oauth2.google.example.yaml)** - Google authentication
 - **[SAML](providers/saml.example.yaml)** - SAML 2.0 SSO
 - **[Google Workspace](providers/gsuite.example.yaml)** - G Suite user management
@@ -214,5 +215,4 @@ For issues or questions:
 - Check the [documentation](../docs/)
 - Review provider-specific troubleshooting guides
 - Open an issue on GitHub
-
 

--- a/examples/providers/oauth.example.yaml
+++ b/examples/providers/oauth.example.yaml
@@ -1,16 +1,16 @@
 version: "1.0"
 providers:
   oauth:
-    name: Oauth example
-    description: Oauth example provider
+    name: OAuth2 example
+    description: Generic OAuth2 / OIDC example provider
     provider: oauth2
     enabled: false
     config:
-      authority: https://accounts.google.com/o/oauth2
-      endpoints:
-        token: /token
-        auth: /auth
-      grant: client_credentials
-      client:
-        id: google_client_id
-        secret: google_client_secret
+      client_id: example_client_id
+      client_secret: example_client_secret
+      auth_url: https://auth.example.com/oauth2/authorize
+      token_url: https://auth.example.com/oauth2/token
+      scopes:
+        - openid
+        - profile
+        - email


### PR DESCRIPTION
## Summary
- update the generic OAuth2 provider docs to match the implemented flat config schema
- remove unsupported Google OAuth2 fields from the docs and clarify provider defaults/behavior
- refresh the generic OAuth2 example and add it to the examples index

## Verification
- git diff --check
- attempted   `bundle exec jekyll build` in `docs/`, but it failed locally because Bundler 4.0.1 is not installed in this environment