### PR TITLE
feat: add OIDC discovery defaults to generic oauth2 provider

### DIFF
--- a/docs/configuration/providers/oauth2/index.md
+++ b/docs/configuration/providers/oauth2/index.md
@@ -8,14 +8,15 @@ grand_parent: Configuration
 
 # OAuth2 Provider
 
-The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or OpenID Connect provider. Use it when you need to supply custom authorization and token endpoint URLs instead of relying on a built-in provider such as `oauth2.google`.
+The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or OpenID Connect provider. Use it when you need a flexible OIDC-capable provider without relying on a built-in integration such as `oauth2.google`.
 
 ## Capabilities
 
 - **Authentication**: Interactive OAuth2 authorization code flow
-- **Generic Integration**: Works with providers that expose standard authorization and token endpoints
+- **Generic Integration**: Works with providers that expose standard OIDC discovery or standard authorization/token endpoints
 - **Identity Discovery**: Builds user identities from an ID token or a compatible `userinfo` endpoint
-- **Customizable Endpoints**: Lets you provide full authorization and token URLs directly
+- **OIDC Discovery**: Can derive OAuth2 endpoints from an OIDC discovery document
+- **Customizable Endpoints**: Lets you override discovered endpoints explicitly when needed
 
 ## Prerequisites
 
@@ -28,8 +29,7 @@ The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or Op
 
 ### Required OAuth2 Configuration
 
-- **Authorization Endpoint**: Full authorization URL
-- **Token Endpoint**: Full token exchange URL
+- **Authority or Endpoints**: Either an OIDC authority URL or explicit authorization and token endpoint URLs
 - **Client ID**: OAuth2 application client identifier
 - **Client Secret**: OAuth2 application client secret
 
@@ -39,19 +39,23 @@ The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or Op
 |--------|------|----------|---------|-------------|
 | `client_id` | string | Yes | - | OAuth2 client ID |
 | `client_secret` | string | Yes | - | OAuth2 client secret |
-| `auth_url` | string | Yes* | - | Full authorization endpoint URL |
-| `token_url` | string | Yes* | - | Full token endpoint URL |
+| `authority` | string | Yes* | - | OIDC issuer URL or full `/.well-known/openid-configuration` URL |
+| `auth_url` | string | No | Derived from discovery | Explicit authorization endpoint override |
+| `token_url` | string | No | Derived from discovery | Explicit token endpoint override |
+| `userinfo_url` | string | No | Derived from discovery | Explicit userinfo endpoint override |
 | `redirect_url` | string | No | - | Default redirect URI if one is not supplied at login time |
 | `scopes` | array | No | `["openid"]` | Scopes requested during authorization |
 
-\* The schema accepts omitted values, but the generic provider does not supply defaults. In practice you should set both `auth_url` and `token_url`.
+\* Set either `authority`, or both `auth_url` and `token_url`.
 
 ## Behavior Notes
 
 - This provider is built around the OAuth2 authorization code flow used for browser login.
+- If `authority` is set, the provider fetches the OIDC discovery document lazily at login time and reads `authorization_endpoint`, `token_endpoint`, and `userinfo_endpoint` from it.
+- `authority` accepts either an issuer base URL such as `https://auth.example.com/realms/demo` or a full discovery URL ending in `/.well-known/openid-configuration`.
+- Explicit `auth_url`, `token_url`, and `userinfo_url` values override the discovered defaults when they are set.
 - The provider always includes the `openid` scope during authorization if it is missing from the requested scope list.
-- User details are read from the returned `id_token` when present. If no ID token is returned, the provider tries a `userinfo` endpoint derived from `token_url` by replacing `/token` with `/userinfo`.
-- This provider does not perform OIDC discovery. You must configure the endpoint URLs explicitly.
+- User details are read from the returned `id_token` when present. If no ID token is returned, the provider tries the resolved `userinfo` endpoint and finally falls back to deriving one from `token_url` by replacing `/token` with `/userinfo`.
 
 ## Example Configurations
 
@@ -68,8 +72,7 @@ providers:
     config:
       client_id: YOUR_CLIENT_ID
       client_secret: YOUR_CLIENT_SECRET
-      auth_url: https://auth.example.com/oauth2/authorize
-      token_url: https://auth.example.com/oauth2/token
+      authority: https://auth.example.com
       redirect_url: https://agent.example.com/auth/callback
       scopes:
         - openid
@@ -77,21 +80,22 @@ providers:
         - email
 ```
 
-### Google via Generic OAuth2
+### OIDC Discovery With Explicit Overrides
 
 ```yaml
 version: "1.0"
 providers:
-  google-oauth2:
-    name: Google OAuth2
-    description: Google OAuth2 authentication
+  internal-oidc:
+    name: Internal OIDC
+    description: OIDC authentication with an internal token and userinfo path override
     provider: oauth2
     enabled: true
     config:
-      client_id: YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com
-      client_secret: YOUR_GOOGLE_CLIENT_SECRET
-      auth_url: https://accounts.google.com/o/oauth2/v2/auth
-      token_url: https://oauth2.googleapis.com/token
+      client_id: YOUR_CLIENT_ID
+      client_secret: YOUR_CLIENT_SECRET
+      authority: https://auth.example.com/realms/team-a
+      token_url: https://auth.internal.example.com/realms/team-a/protocol/openid-connect/token
+      userinfo_url: https://auth.internal.example.com/realms/team-a/protocol/openid-connect/userinfo
       scopes:
         - openid
         - profile

--- a/docs/configuration/providers/oauth2/index.md
+++ b/docs/configuration/providers/oauth2/index.md
@@ -43,6 +43,7 @@ The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or Op
 | `auth_url` | string | No | Derived from discovery | Explicit authorization endpoint override |
 | `token_url` | string | No | Derived from discovery | Explicit token endpoint override |
 | `userinfo_url` | string | No | Derived from discovery | Explicit userinfo endpoint override |
+| `username_claim` | string | No | `preferred_username`, then `username` | Claim copied into `user.username` |
 | `redirect_url` | string | No | - | Default redirect URI if one is not supplied at login time |
 | `scopes` | array | No | `["openid"]` | Scopes requested during authorization |
 
@@ -56,6 +57,8 @@ The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or Op
 - Explicit `auth_url`, `token_url`, and `userinfo_url` values override the discovered defaults when they are set.
 - The provider always includes the `openid` scope during authorization if it is missing from the requested scope list.
 - User details are read from the returned `id_token` when present. If no ID token is returned, the provider tries the resolved `userinfo` endpoint and finally falls back to deriving one from `token_url` by replacing `/token` with `/userinfo`.
+- `user.username` is populated from `username_claim` when configured. If omitted, the provider tries `preferred_username` and then `username`.
+- Username is never inferred from the email local-part.
 
 ## Example Configurations
 
@@ -73,6 +76,7 @@ providers:
       client_id: YOUR_CLIENT_ID
       client_secret: YOUR_CLIENT_SECRET
       authority: https://auth.example.com
+      username_claim: preferred_username
       redirect_url: https://agent.example.com/auth/callback
       scopes:
         - openid

--- a/docs/configuration/providers/oauth2/index.md
+++ b/docs/configuration/providers/oauth2/index.md
@@ -40,8 +40,8 @@ The OAuth2 provider enables browser-based sign-in against a generic OAuth2 or Op
 | `client_id` | string | Yes | - | OAuth2 client ID |
 | `client_secret` | string | Yes | - | OAuth2 client secret |
 | `authority` | string | Yes* | - | OIDC issuer URL or full `/.well-known/openid-configuration` URL |
-| `auth_url` | string | No | Derived from discovery | Explicit authorization endpoint override |
-| `token_url` | string | No | Derived from discovery | Explicit token endpoint override |
+| `auth_url` | string | Yes* | Derived from discovery | Explicit authorization endpoint override |
+| `token_url` | string | Yes* | Derived from discovery | Explicit token endpoint override |
 | `userinfo_url` | string | No | Derived from discovery | Explicit userinfo endpoint override |
 | `username_claim` | string | No | `preferred_username`, then `username` | Claim copied into `user.username` |
 | `redirect_url` | string | No | - | Default redirect URI if one is not supplied at login time |

--- a/examples/providers/oauth.example.yaml
+++ b/examples/providers/oauth.example.yaml
@@ -8,8 +8,11 @@ providers:
     config:
       client_id: example_client_id
       client_secret: example_client_secret
-      auth_url: https://auth.example.com/oauth2/authorize
-      token_url: https://auth.example.com/oauth2/token
+      authority: https://auth.example.com
+      # Optional manual overrides. Explicit values win over discovery.
+      # auth_url: https://auth.example.com/oauth2/authorize
+      # token_url: https://auth.example.com/oauth2/token
+      # userinfo_url: https://auth.internal.example.com/oauth2/userinfo
       scopes:
         - openid
         - profile

--- a/examples/providers/oauth.example.yaml
+++ b/examples/providers/oauth.example.yaml
@@ -9,6 +9,7 @@ providers:
       client_id: example_client_id
       client_secret: example_client_secret
       authority: https://auth.example.com
+      username_claim: preferred_username
       # Optional manual overrides. Explicit values win over discovery.
       # auth_url: https://auth.example.com/oauth2/authorize
       # token_url: https://auth.example.com/oauth2/token

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -386,6 +386,17 @@ func (c *Config) initializeSingleProvider(providerKey string, p *models.Provider
 		return nil, fmt.Errorf("failed to resolve environment variables for provider %s: %w", providerKey, err)
 	}
 
+	// Client mode proxies provider operations to the login server and should not
+	// require the full provider config locally. Synced provider metadata from
+	// /providers intentionally omits sensitive config such as client secrets, but
+	// any non-sensitive config that is present should still be resolved first.
+	if c.IsClient() {
+		if err := impl.Initialize(providerKey, *p); err != nil {
+			return nil, err
+		}
+		return impl, nil
+	}
+
 	err = providerSdk.ValidateConfig(p.Provider, p.Config)
 
 	if err != nil {

--- a/internal/config/providers_client_test.go
+++ b/internal/config/providers_client_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/thand-io/agent/internal/models"
+)
+
+func TestInitializeSingleProvider_ClientModeSkipsConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	loginServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer loginServer.Close()
+
+	cfg := &Config{
+		mode: ModeClient,
+		Login: models.LoginConfig{
+			Endpoint: &model.Endpoint{
+				EndpointConfig: &model.EndpointConfiguration{
+					URI: &model.LiteralUri{Value: loginServer.URL},
+				},
+			},
+		},
+	}
+
+	providerCfg := &models.ProviderConfig{
+		Name:        "JumpCloud OAuth2",
+		Description: "Config-less synced provider metadata",
+		Provider:    "oauth2",
+		Enabled:     true,
+		Config: &models.BasicConfig{
+			"redirect_url": `${ .THAND_REDIRECT_URL // "http://localhost/callback" }`,
+		},
+	}
+
+	impl, err := cfg.initializeSingleProvider("oauth2-jumpcloud", providerCfg)
+	if err != nil {
+		t.Fatalf("initializeSingleProvider() error = %v", err)
+	}
+	if impl == nil {
+		t.Fatal("initializeSingleProvider() returned nil provider")
+	}
+
+	if got := fmt.Sprintf("%T", impl); got != "*providers.remoteProviderProxy" {
+		t.Fatalf("initializeSingleProvider() type = %s, want *providers.remoteProviderProxy", got)
+	}
+	if impl.GetIdentifier() != "oauth2-jumpcloud" {
+		t.Fatalf("proxy identifier = %q, want %q", impl.GetIdentifier(), "oauth2-jumpcloud")
+	}
+	if impl.GetProvider() != "oauth2" {
+		t.Fatalf("proxy provider = %q, want %q", impl.GetProvider(), "oauth2")
+	}
+	if got, ok := impl.GetConfig().GetString("redirect_url"); !ok || got != "http://localhost/callback" {
+		t.Fatalf("proxy config redirect_url = %q, %v; want %q, true", got, ok, "http://localhost/callback")
+	}
+}
+
+func TestInitializeSingleProvider_ServerModeStillValidatesConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{mode: ModeServer}
+	providerCfg := &models.ProviderConfig{
+		Name:        "JumpCloud OAuth2",
+		Description: "Missing required oauth2 credentials",
+		Provider:    "oauth2",
+		Enabled:     true,
+	}
+
+	_, err := cfg.initializeSingleProvider("oauth2-jumpcloud", providerCfg)
+	if err == nil {
+		t.Fatal("initializeSingleProvider() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "provider config validation failed") {
+		t.Fatalf("initializeSingleProvider() error = %v, want provider config validation failure", err)
+	}
+}

--- a/internal/daemon/middleware.go
+++ b/internal/daemon/middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/thand-io/agent/internal/common"
+	"github.com/thand-io/agent/internal/config"
 	"github.com/thand-io/agent/internal/models"
 	gcpiap "github.com/thand-io/agent/internal/providers/gcp.iap"
 	sessionManager "github.com/thand-io/agent/internal/sessions"
@@ -562,7 +563,7 @@ func (s *Server) getSession(c *gin.Context, authProviders ...string) (string, *m
 					WithField("user_id", foundUser.ID).
 					Warnln("Failed to resolve identity for user in session")
 			} else if compositeIdentity.User != nil {
-				foundSession.User = compositeIdentity.User
+				foundSession.User = mergeSessionUserWithIdentity(foundUser, compositeIdentity)
 			} else {
 				logrus.WithField("user_id", foundUser.ID).
 					Warnln("No user information found in resolved identity for session user")
@@ -658,4 +659,26 @@ func (s *Server) getUserSessions(c *gin.Context) (map[string]*models.Session, er
 	}
 
 	return remoteSession, nil
+}
+
+func mergeSessionUserWithIdentity(sessionUser *models.User, compositeIdentity *models.Identity) *models.User {
+	if sessionUser == nil {
+		if compositeIdentity != nil {
+			return compositeIdentity.User
+		}
+		return nil
+	}
+
+	if compositeIdentity == nil || compositeIdentity.User == nil {
+		return sessionUser
+	}
+
+	sessionIdentity := config.DeepCopyIdentity(&models.Identity{
+		ID:    sessionUser.GetMappableIdentifier(),
+		Label: sessionUser.GetName(),
+		User:  sessionUser,
+	})
+	config.MergeIdentities(sessionIdentity, compositeIdentity)
+
+	return sessionIdentity.User
 }

--- a/internal/daemon/middleware_test.go
+++ b/internal/daemon/middleware_test.go
@@ -10,6 +10,94 @@ import (
 	"github.com/thand-io/agent/internal/models"
 )
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func TestMergeSessionUserWithIdentity_PreservesFreshSessionFields(t *testing.T) {
+	sessionUser := &models.User{
+		ID:       "user-123",
+		Email:    "user@example.com",
+		Username: "fresh-user",
+		Name:     "Fresh User",
+		Verified: boolPtr(true),
+		Source:   "oauth2",
+		Groups:   []string{"session-admins"},
+	}
+
+	compositeIdentity := &models.Identity{
+		ID:    "user@example.com",
+		Label: "Stale User",
+		User: &models.User{
+			ID:       "stale-id",
+			Email:    "user@example.com",
+			Username: "",
+			Name:     "Stale Name",
+			Verified: boolPtr(false),
+			Source:   "cached-provider",
+			Groups:   []string{"session-admins", "identity-auditors"},
+		},
+	}
+
+	merged := mergeSessionUserWithIdentity(sessionUser, compositeIdentity)
+
+	assert.Equal(t, "user-123", merged.ID)
+	assert.Equal(t, "user@example.com", merged.Email)
+	assert.Equal(t, "fresh-user", merged.Username)
+	assert.Equal(t, "Fresh User", merged.Name)
+	assert.Equal(t, "oauth2", merged.Source)
+	if assert.NotNil(t, merged.Verified) {
+		assert.True(t, *merged.Verified)
+	}
+	assert.ElementsMatch(t, []string{"session-admins", "identity-auditors"}, merged.Groups)
+}
+
+func TestMergeSessionUserWithIdentity_FillsMissingSessionFields(t *testing.T) {
+	sessionUser := &models.User{
+		ID:     "user-123",
+		Email:  "user@example.com",
+		Name:   "Fresh User",
+		Source: "oauth2",
+	}
+
+	compositeIdentity := &models.Identity{
+		ID:    "user@example.com",
+		Label: "Cached User",
+		User: &models.User{
+			ID:       "user-123",
+			Email:    "user@example.com",
+			Username: "cached-user",
+			Name:     "Cached User",
+			Verified: boolPtr(true),
+			Source:   "cached-provider",
+			Groups:   []string{"identity-auditors"},
+		},
+	}
+
+	merged := mergeSessionUserWithIdentity(sessionUser, compositeIdentity)
+
+	assert.Equal(t, "cached-user", merged.Username)
+	if assert.NotNil(t, merged.Verified) {
+		assert.True(t, *merged.Verified)
+	}
+	assert.Equal(t, "oauth2", merged.Source)
+	assert.ElementsMatch(t, []string{"identity-auditors"}, merged.Groups)
+}
+
+func TestMergeSessionUserWithIdentity_LeavesSessionUnchangedWithoutCompositeUser(t *testing.T) {
+	sessionUser := &models.User{
+		ID:       "user-123",
+		Email:    "user@example.com",
+		Username: "fresh-user",
+		Name:     "Fresh User",
+		Source:   "oauth2",
+	}
+
+	merged := mergeSessionUserWithIdentity(sessionUser, &models.Identity{ID: "user@example.com"})
+
+	assert.Equal(t, sessionUser, merged)
+}
+
 func TestMatchOrigin(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/models/provider_schema.go
+++ b/internal/models/provider_schema.go
@@ -91,8 +91,10 @@ type OAuth2Config struct {
 	ClientSecret string   `json:"client_secret" mapstructure:"client_secret" validate:"required" sensitive:"true"`
 	Scopes       []string `json:"scopes" mapstructure:"scopes"`
 	RedirectURL  string   `json:"redirect_url" mapstructure:"redirect_url" validate:"omitempty,url"`
+	Authority    string   `json:"authority" mapstructure:"authority" validate:"omitempty,url"`
 	AuthURL      string   `json:"auth_url" mapstructure:"auth_url" validate:"omitempty,url"`
 	TokenURL     string   `json:"token_url" mapstructure:"token_url" validate:"omitempty,url"`
+	UserInfoURL  string   `json:"userinfo_url" mapstructure:"userinfo_url" validate:"omitempty,url"`
 }
 
 // SMTPConfig represents SMTP email configuration

--- a/internal/models/provider_schema.go
+++ b/internal/models/provider_schema.go
@@ -87,14 +87,15 @@ type GCPCredentials struct {
 
 // OAuth2Config represents common OAuth2 configuration
 type OAuth2Config struct {
-	ClientID     string   `json:"client_id" mapstructure:"client_id" validate:"required"`
-	ClientSecret string   `json:"client_secret" mapstructure:"client_secret" validate:"required" sensitive:"true"`
-	Scopes       []string `json:"scopes" mapstructure:"scopes"`
-	RedirectURL  string   `json:"redirect_url" mapstructure:"redirect_url" validate:"omitempty,url"`
-	Authority    string   `json:"authority" mapstructure:"authority" validate:"omitempty,url"`
-	AuthURL      string   `json:"auth_url" mapstructure:"auth_url" validate:"omitempty,url"`
-	TokenURL     string   `json:"token_url" mapstructure:"token_url" validate:"omitempty,url"`
-	UserInfoURL  string   `json:"userinfo_url" mapstructure:"userinfo_url" validate:"omitempty,url"`
+	ClientID      string   `json:"client_id" mapstructure:"client_id" validate:"required"`
+	ClientSecret  string   `json:"client_secret" mapstructure:"client_secret" validate:"required" sensitive:"true"`
+	Scopes        []string `json:"scopes" mapstructure:"scopes"`
+	RedirectURL   string   `json:"redirect_url" mapstructure:"redirect_url" validate:"omitempty,url"`
+	UsernameClaim string   `json:"username_claim" mapstructure:"username_claim"`
+	Authority     string   `json:"authority" mapstructure:"authority" validate:"omitempty,url"`
+	AuthURL       string   `json:"auth_url" mapstructure:"auth_url" validate:"omitempty,url"`
+	TokenURL      string   `json:"token_url" mapstructure:"token_url" validate:"omitempty,url"`
+	UserInfoURL   string   `json:"userinfo_url" mapstructure:"userinfo_url" validate:"omitempty,url"`
 }
 
 // SMTPConfig represents SMTP email configuration

--- a/internal/providers/aws/rbac_iam.go
+++ b/internal/providers/aws/rbac_iam.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -105,7 +106,6 @@ func (p *awsProvider) authorizeRoleTraditionalIAM(
 // revokeRoleTraditionalIAM handles role revocation for traditional IAM users.
 // Uses GetIAMRole (read-only) to prevent silently re-creating a deleted role.
 func (p *awsProvider) revokeRoleTraditionalIAM(task models.ProviderContext, user *models.User, role *models.CompositeRole) (*models.RevokeRoleResponse, error) {
-
 	// Step 1 — resolve the existing role; fail fast if not found, never create
 	roleResp, err := p.execGetIAMRole(task, &GetIAMRoleRequest{Role: &role.Role, RoleName: role.GetName()})
 	if err != nil {
@@ -258,7 +258,7 @@ func (p *awsProvider) attachPoliciesToRole(ctx context.Context, roleName string,
 
 // bindUserToRole creates or updates the assume role policy to allow the user to assume the role
 func (p *awsProvider) bindUserToRole(ctx context.Context, user *models.User, roleName string, targetAccountID string) error {
-	username := p.getUsernameForIAM(user)
+	username := p.getPreferredIAMUsername(user)
 	if len(username) == 0 {
 		return fmt.Errorf("failed to determine username for user")
 	}
@@ -311,48 +311,19 @@ func (p *awsProvider) unbindUserFromRole(ctx context.Context, user *models.User,
 		}
 	}
 
-	// Extract username from email
-	username := p.getUsernameForIAM(user)
-	if len(username) == 0 {
+	usernameCandidates := p.getIAMPrincipalUsernames(user)
+	if len(usernameCandidates) == 0 {
 		// If no username can be determined, nothing to unbind specifically
 		// The role will still have the account root principal
 		return fmt.Errorf("failed to determine username for user")
 	}
-	userArn := fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, username)
+	userArns := make(map[string]struct{}, len(usernameCandidates))
+	for _, username := range usernameCandidates {
+		userArns[fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, username)] = struct{}{}
+	}
 
 	// Remove statements that reference this user
-	var newStatements []Statement
-	for _, stmt := range currentPolicy.Statement {
-		// Check if this statement references our user
-		if principal, ok := stmt.Principal.(map[string]any); ok {
-			if awsPrincipal, exists := principal["AWS"]; exists {
-				if awsStr, ok := awsPrincipal.(string); ok && awsStr == userArn {
-					// Skip this statement - we're removing the user
-					continue
-				}
-			}
-		}
-		newStatements = append(newStatements, stmt)
-	}
-
-	// If no statements remain, create a minimal deny-all policy to prevent open access
-	if len(newStatements) == 0 {
-		newStatements = []Statement{
-			{
-				Effect: "Deny",
-				Principal: map[string]string{
-					"AWS": "*",
-				},
-				Action: "sts:AssumeRole",
-			},
-		}
-	}
-
-	// Create new policy document
-	newPolicy := PolicyDocument{
-		Version:   "2012-10-17",
-		Statement: newStatements,
-	}
+	newPolicy := buildUnboundAssumeRolePolicy(currentPolicy, userArns)
 
 	// Update the assume role policy
 	newPolicyJSON, err := json.Marshal(newPolicy)
@@ -371,16 +342,131 @@ func (p *awsProvider) unbindUserFromRole(ctx context.Context, user *models.User,
 	return nil
 }
 
-// getUsernameForIAM determines the appropriate username for AWS IAM user ARN
-// Priority: Username field > email prefix > empty string (fallback to account root)
-func (p *awsProvider) getUsernameForIAM(user *models.User) string {
-	if len(user.Username) > 0 {
-		return user.Username
+// getPreferredIAMUsername determines the canonical username to use when writing
+// IAM principals. It prefers an explicitly non-email username, otherwise falls
+// back to an email-derived local-part form.
+func (p *awsProvider) getPreferredIAMUsername(user *models.User) string {
+	candidates := p.getIAMPrincipalUsernames(user)
+	if len(candidates) == 0 {
+		return ""
 	}
-	if len(user.Email) > 0 {
-		return common.ExtractUsernameFromEmail(user.Email)
+	return candidates[0]
+}
+
+// getIAMPrincipalUsernames returns the set of plausible IAM username forms for
+// a user. This keeps bind and revoke tolerant of users hydrated with either a
+// raw IAM username or an email-style username.
+func (p *awsProvider) getIAMPrincipalUsernames(user *models.User) []string {
+	if user == nil {
+		return nil
 	}
-	return ""
+
+	var candidates []string
+	addCandidate := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range candidates {
+			if existing == value {
+				return
+			}
+		}
+		candidates = append(candidates, value)
+	}
+
+	if username := strings.TrimSpace(user.Username); username != "" && !strings.Contains(username, "@") {
+		addCandidate(username)
+	}
+	if username := strings.TrimSpace(user.Username); strings.Contains(username, "@") {
+		addCandidate(common.ExtractUsernameFromEmail(username))
+	}
+	if email := strings.TrimSpace(user.Email); email != "" {
+		addCandidate(common.ExtractUsernameFromEmail(email))
+	}
+	if username := strings.TrimSpace(user.Username); username != "" {
+		addCandidate(username)
+	}
+	if email := strings.TrimSpace(user.Email); email != "" {
+		addCandidate(email)
+	}
+
+	return candidates
+}
+
+func removeIAMUserStatements(statements []Statement, userArns map[string]struct{}) []Statement {
+	var newStatements []Statement
+	for _, stmt := range statements {
+		if statementReferencesAnyIAMUserArn(stmt, userArns) {
+			continue
+		}
+		newStatements = append(newStatements, stmt)
+	}
+	return newStatements
+}
+
+func buildUnboundAssumeRolePolicy(currentPolicy PolicyDocument, userArns map[string]struct{}) PolicyDocument {
+	newStatements := removeIAMUserStatements(currentPolicy.Statement, userArns)
+	if len(newStatements) == 0 {
+		newStatements = []Statement{
+			{
+				Effect: "Deny",
+				Principal: map[string]string{
+					"AWS": "*",
+				},
+				Action: "sts:AssumeRole",
+			},
+		}
+	}
+
+	return PolicyDocument{
+		Version:   "2012-10-17",
+		Statement: newStatements,
+	}
+}
+
+func statementReferencesAnyIAMUserArn(stmt Statement, userArns map[string]struct{}) bool {
+	if len(userArns) == 0 {
+		return false
+	}
+
+	principal, ok := stmt.Principal.(map[string]any)
+	if !ok {
+		if principalStringMap, ok := stmt.Principal.(map[string]string); ok {
+			if awsPrincipal, exists := principalStringMap["AWS"]; exists {
+				_, found := userArns[awsPrincipal]
+				return found
+			}
+		}
+		return false
+	}
+
+	awsPrincipal, exists := principal["AWS"]
+	if !exists {
+		return false
+	}
+
+	switch value := awsPrincipal.(type) {
+	case string:
+		_, found := userArns[value]
+		return found
+	case []string:
+		for _, principalArn := range value {
+			if _, found := userArns[principalArn]; found {
+				return true
+			}
+		}
+	case []any:
+		for _, principalValue := range value {
+			if principalArn, ok := principalValue.(string); ok {
+				if _, found := userArns[principalArn]; found {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/providers/aws/rbac_iam_test.go
+++ b/internal/providers/aws/rbac_iam_test.go
@@ -35,6 +35,16 @@ func TestGetIAMPrincipalUsernames(t *testing.T) {
 		)
 		assert.Equal(t, "engineer", provider.getPreferredIAMUsername(user))
 	})
+
+	t.Run("email shaped oauth2 username still normalizes to iam local part", func(t *testing.T) {
+		user := &models.User{
+			Username: "testuser@thand.io",
+			Email:    "testuser@thand.io",
+			Source:   "oauth2",
+		}
+
+		assert.Equal(t, "testuser", provider.getPreferredIAMUsername(user))
+	})
 }
 
 func TestBuildUnboundAssumeRolePolicy(t *testing.T) {

--- a/internal/providers/aws/rbac_iam_test.go
+++ b/internal/providers/aws/rbac_iam_test.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thand-io/agent/internal/models"
+)
+
+func TestGetIAMPrincipalUsernames(t *testing.T) {
+	provider := &awsProvider{}
+
+	t.Run("email username includes prefix first", func(t *testing.T) {
+		user := &models.User{
+			Username: "testuser@thand.io",
+			Email:    "testuser@thand.io",
+		}
+
+		assert.Equal(t,
+			[]string{"testuser", "testuser@thand.io"},
+			provider.getIAMPrincipalUsernames(user),
+		)
+		assert.Equal(t, "testuser", provider.getPreferredIAMUsername(user))
+	})
+
+	t.Run("explicit iam username stays preferred", func(t *testing.T) {
+		user := &models.User{
+			Username: "engineer",
+			Email:    "engineer@thand.io",
+		}
+
+		assert.Equal(t,
+			[]string{"engineer", "engineer@thand.io"},
+			provider.getIAMPrincipalUsernames(user),
+		)
+		assert.Equal(t, "engineer", provider.getPreferredIAMUsername(user))
+	})
+}
+
+func TestBuildUnboundAssumeRolePolicy(t *testing.T) {
+	t.Run("removes email prefix match and falls back to deny", func(t *testing.T) {
+		currentPolicy := PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []Statement{
+				{
+					Effect: "Allow",
+					Principal: map[string]any{
+						"AWS": "arn:aws:iam::000000000000:user/testuser",
+					},
+					Action: "sts:AssumeRole",
+				},
+			},
+		}
+		userArns := map[string]struct{}{
+			"arn:aws:iam::000000000000:user/testuser":          {},
+			"arn:aws:iam::000000000000:user/testuser@thand.io": {},
+		}
+
+		updatedPolicy := buildUnboundAssumeRolePolicy(currentPolicy, userArns)
+		assert.Equal(t, "2012-10-17", updatedPolicy.Version)
+		assert.Len(t, updatedPolicy.Statement, 1)
+		assert.Equal(t, "Deny", updatedPolicy.Statement[0].Effect)
+		assert.Equal(t, "sts:AssumeRole", updatedPolicy.Statement[0].Action)
+		assert.Equal(t, map[string]string{
+			"AWS": "*",
+		}, updatedPolicy.Statement[0].Principal)
+	})
+
+	t.Run("keeps non matching statements", func(t *testing.T) {
+		currentPolicy := PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []Statement{
+				{
+					Effect: "Allow",
+					Principal: map[string]any{
+						"AWS": "arn:aws:iam::000000000000:user/other-user",
+					},
+					Action: "sts:AssumeRole",
+				},
+				{
+					Effect: "Allow",
+					Principal: map[string]any{
+						"AWS": "arn:aws:iam::000000000000:user/engineer",
+					},
+					Action: "sts:AssumeRole",
+				},
+			},
+		}
+		userArns := map[string]struct{}{
+			"arn:aws:iam::000000000000:user/engineer":          {},
+			"arn:aws:iam::000000000000:user/engineer@thand.io": {},
+		}
+
+		updatedPolicy := buildUnboundAssumeRolePolicy(currentPolicy, userArns)
+		assert.Len(t, updatedPolicy.Statement, 1)
+		assert.Equal(t, "Allow", updatedPolicy.Statement[0].Effect)
+		assert.Equal(t, map[string]any{
+			"AWS": "arn:aws:iam::000000000000:user/other-user",
+		}, updatedPolicy.Statement[0].Principal)
+	})
+}
+
+func TestRemoveIAMUserStatements(t *testing.T) {
+	t.Run("removes matching statements", func(t *testing.T) {
+		statements := []Statement{
+			{
+				Effect: "Allow",
+				Principal: map[string]any{
+					"AWS": "arn:aws:iam::000000000000:user/testuser",
+				},
+				Action: "sts:AssumeRole",
+			},
+		}
+		userArns := map[string]struct{}{
+			"arn:aws:iam::000000000000:user/testuser":          {},
+			"arn:aws:iam::000000000000:user/testuser@thand.io": {},
+		}
+
+		remaining := removeIAMUserStatements(statements, userArns)
+		assert.Empty(t, remaining)
+	})
+}

--- a/internal/providers/oauth2/discovery.go
+++ b/internal/providers/oauth2/discovery.go
@@ -1,0 +1,137 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const oidcDiscoveryPath = "/.well-known/openid-configuration"
+
+type oidcDiscoveryDocument struct {
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserInfoEndpoint      string `json:"userinfo_endpoint"`
+}
+
+type resolvedOAuth2Config struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	Scopes       []string
+	Authority    string
+	AuthURL      string
+	TokenURL     string
+	UserInfoURL  string
+}
+
+func (p *oauth2Provider) getResolvedConfig(ctx context.Context) (*resolvedOAuth2Config, error) {
+	p.resolvedConfigMu.RLock()
+	if p.resolvedConfig != nil {
+		defer p.resolvedConfigMu.RUnlock()
+		return p.resolvedConfig, nil
+	}
+	p.resolvedConfigMu.RUnlock()
+	p.resolvedConfigMu.Lock()
+	defer p.resolvedConfigMu.Unlock()
+
+	if p.resolvedConfig != nil {
+		return p.resolvedConfig, nil
+	}
+	schema := &ConfigSchema{}
+	if err := schema.Unmarshal(p.GetConfig()); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal OAuth2 config: %w", err)
+	}
+
+	resolved := &resolvedOAuth2Config{
+		ClientID:     schema.ClientID,
+		ClientSecret: schema.ClientSecret,
+		RedirectURL:  schema.RedirectURL,
+		Scopes:       append([]string(nil), schema.Scopes...),
+		Authority:    schema.Authority,
+		AuthURL:      schema.AuthURL,
+		TokenURL:     schema.TokenURL,
+		UserInfoURL:  schema.UserInfoURL,
+	}
+	needsDiscovery := strings.TrimSpace(resolved.AuthURL) == "" ||
+		strings.TrimSpace(resolved.TokenURL) == "" ||
+		strings.TrimSpace(resolved.UserInfoURL) == ""
+
+	if strings.TrimSpace(schema.Authority) != "" && needsDiscovery {
+		discoveryURL := normalizeDiscoveryURL(schema.Authority)
+		document, err := fetchOIDCDiscoveryDocument(ctx, discoveryURL)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(resolved.AuthURL) == "" {
+			resolved.AuthURL = document.AuthorizationEndpoint
+		}
+		if strings.TrimSpace(resolved.TokenURL) == "" {
+			resolved.TokenURL = document.TokenEndpoint
+		}
+		if strings.TrimSpace(resolved.UserInfoURL) == "" {
+			resolved.UserInfoURL = document.UserInfoEndpoint
+		}
+	}
+
+	if strings.TrimSpace(resolved.AuthURL) == "" {
+		return nil, fmt.Errorf("OAuth2 config resolution failed: authorization endpoint is empty")
+	}
+	if strings.TrimSpace(resolved.TokenURL) == "" {
+		return nil, fmt.Errorf("OAuth2 config resolution failed: token endpoint is empty")
+	}
+	p.resolvedConfig = resolved
+	return p.resolvedConfig, nil
+}
+
+func normalizeDiscoveryURL(authority string) string {
+	trimmed := strings.TrimSpace(authority)
+	parsedURL, err := url.Parse(trimmed)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		normalized := strings.TrimRight(trimmed, "/")
+		if strings.HasSuffix(normalized, oidcDiscoveryPath) {
+			return normalized
+		}
+		return normalized + oidcDiscoveryPath
+	}
+
+	normalizedPath := strings.TrimRight(parsedURL.Path, "/")
+	if strings.HasSuffix(normalizedPath, oidcDiscoveryPath) {
+		parsedURL.Path = normalizedPath
+		return parsedURL.String()
+	}
+	if normalizedPath == "" {
+		parsedURL.Path = oidcDiscoveryPath
+	} else {
+		parsedURL.Path = normalizedPath + oidcDiscoveryPath
+	}
+
+	return parsedURL.String()
+}
+
+func fetchOIDCDiscoveryDocument(ctx context.Context, discoveryURL string) (*oidcDiscoveryDocument, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OIDC discovery request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC discovery request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OIDC discovery endpoint returned %d", resp.StatusCode)
+	}
+
+	var document oidcDiscoveryDocument
+	if err := json.NewDecoder(resp.Body).Decode(&document); err != nil {
+		return nil, fmt.Errorf("failed to decode OIDC discovery response: %w", err)
+	}
+
+	return &document, nil
+}

--- a/internal/providers/oauth2/discovery.go
+++ b/internal/providers/oauth2/discovery.go
@@ -18,14 +18,15 @@ type oidcDiscoveryDocument struct {
 }
 
 type resolvedOAuth2Config struct {
-	ClientID     string
-	ClientSecret string
-	RedirectURL  string
-	Scopes       []string
-	Authority    string
-	AuthURL      string
-	TokenURL     string
-	UserInfoURL  string
+	ClientID      string
+	ClientSecret  string
+	RedirectURL   string
+	Scopes        []string
+	UsernameClaim string
+	Authority     string
+	AuthURL       string
+	TokenURL      string
+	UserInfoURL   string
 }
 
 func (p *oauth2Provider) getResolvedConfig(ctx context.Context) (*resolvedOAuth2Config, error) {
@@ -47,14 +48,15 @@ func (p *oauth2Provider) getResolvedConfig(ctx context.Context) (*resolvedOAuth2
 	}
 
 	resolved := &resolvedOAuth2Config{
-		ClientID:     schema.ClientID,
-		ClientSecret: schema.ClientSecret,
-		RedirectURL:  schema.RedirectURL,
-		Scopes:       append([]string(nil), schema.Scopes...),
-		Authority:    schema.Authority,
-		AuthURL:      schema.AuthURL,
-		TokenURL:     schema.TokenURL,
-		UserInfoURL:  schema.UserInfoURL,
+		ClientID:      schema.ClientID,
+		ClientSecret:  schema.ClientSecret,
+		RedirectURL:   schema.RedirectURL,
+		Scopes:        append([]string(nil), schema.Scopes...),
+		UsernameClaim: schema.UsernameClaim,
+		Authority:     schema.Authority,
+		AuthURL:       schema.AuthURL,
+		TokenURL:      schema.TokenURL,
+		UserInfoURL:   schema.UserInfoURL,
 	}
 	needsDiscovery := strings.TrimSpace(resolved.AuthURL) == "" ||
 		strings.TrimSpace(resolved.TokenURL) == "" ||

--- a/internal/providers/oauth2/discovery.go
+++ b/internal/providers/oauth2/discovery.go
@@ -64,7 +64,7 @@ func (p *oauth2Provider) getResolvedConfig(ctx context.Context) (*resolvedOAuth2
 
 	if strings.TrimSpace(schema.Authority) != "" && needsDiscovery {
 		discoveryURL := normalizeDiscoveryURL(schema.Authority)
-		document, err := fetchOIDCDiscoveryDocument(ctx, discoveryURL)
+		document, err := fetchOIDCDiscoveryDocument(ctx, p.getHTTPClient(), discoveryURL)
 		if err != nil {
 			return nil, err
 		}
@@ -114,13 +114,13 @@ func normalizeDiscoveryURL(authority string) string {
 	return parsedURL.String()
 }
 
-func fetchOIDCDiscoveryDocument(ctx context.Context, discoveryURL string) (*oidcDiscoveryDocument, error) {
+func fetchOIDCDiscoveryDocument(ctx context.Context, httpClient *http.Client, discoveryURL string) (*oidcDiscoveryDocument, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OIDC discovery request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("OIDC discovery request failed: %w", err)
 	}

--- a/internal/providers/oauth2/main.go
+++ b/internal/providers/oauth2/main.go
@@ -1,7 +1,9 @@
 package oauth2
 
 import (
+	"net/http"
 	"sync"
+	"time"
 
 	"github.com/thand-io/agent/internal/models"
 	"github.com/thand-io/agent/internal/providers"
@@ -9,10 +11,22 @@ import (
 
 const Oauth2ProviderName = "oauth2"
 
+var defaultOutboundHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+func cloneDefaultOutboundHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:       defaultOutboundHTTPClient.Timeout,
+		Transport:     defaultOutboundHTTPClient.Transport,
+		CheckRedirect: defaultOutboundHTTPClient.CheckRedirect,
+		Jar:           defaultOutboundHTTPClient.Jar,
+	}
+}
+
 // oauth2Provider implements the ProviderImpl interface for OAuth2
 type oauth2Provider struct {
 	*models.BaseProvider
 
+	httpClient       *http.Client
 	resolvedConfigMu sync.RWMutex
 	resolvedConfig   *resolvedOAuth2Config
 }
@@ -23,8 +37,17 @@ func (p *oauth2Provider) Initialize(identifier string, provider models.ProviderC
 		provider,
 		OAuth2Capabilities,
 	)
+	p.httpClient = cloneDefaultOutboundHTTPClient()
 	// TODO: Implement OAuth2 initialization logic
 	return nil
+}
+
+func (p *oauth2Provider) getHTTPClient() *http.Client {
+	if p != nil && p.httpClient != nil {
+		return p.httpClient
+	}
+
+	return defaultOutboundHTTPClient
 }
 
 func init() {

--- a/internal/providers/oauth2/main.go
+++ b/internal/providers/oauth2/main.go
@@ -1,6 +1,8 @@
 package oauth2
 
 import (
+	"sync"
+
 	"github.com/thand-io/agent/internal/models"
 	"github.com/thand-io/agent/internal/providers"
 )
@@ -10,6 +12,9 @@ const Oauth2ProviderName = "oauth2"
 // oauth2Provider implements the ProviderImpl interface for OAuth2
 type oauth2Provider struct {
 	*models.BaseProvider
+
+	resolvedConfigMu sync.RWMutex
+	resolvedConfig   *resolvedOAuth2Config
 }
 
 func (p *oauth2Provider) Initialize(identifier string, provider models.ProviderConfig) error {

--- a/internal/providers/oauth2/schema.go
+++ b/internal/providers/oauth2/schema.go
@@ -26,6 +26,9 @@ type ConfigSchema struct {
 	// Optional explicit userinfo endpoint override
 	UserInfoURL string `json:"userinfo_url" mapstructure:"userinfo_url" validate:"omitempty,url"`
 
+	// Optional claim to copy into models.User.Username
+	UsernameClaim string `json:"username_claim" mapstructure:"username_claim"`
+
 	// Requested scopes
 	Scopes []string `json:"scopes" mapstructure:"scopes"`
 

--- a/internal/providers/oauth2/schema.go
+++ b/internal/providers/oauth2/schema.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/thand-io/agent/internal/common"
 	"github.com/thand-io/agent/internal/models"
@@ -15,9 +16,15 @@ type ConfigSchema struct {
 	ClientID     string `json:"client_id" mapstructure:"client_id" validate:"required"`
 	ClientSecret string `json:"client_secret" mapstructure:"client_secret" validate:"required" sensitive:"true"`
 
-	// OAuth2 endpoints (optional if using provider-specific defaults)
+	// OIDC discovery authority (optional if explicit endpoints are set)
+	Authority string `json:"authority" mapstructure:"authority" validate:"omitempty,url"`
+
+	// OAuth2 endpoints (optional if using OIDC discovery)
 	AuthURL  string `json:"auth_url" mapstructure:"auth_url" validate:"omitempty,url"`
 	TokenURL string `json:"token_url" mapstructure:"token_url" validate:"omitempty,url"`
+
+	// Optional explicit userinfo endpoint override
+	UserInfoURL string `json:"userinfo_url" mapstructure:"userinfo_url" validate:"omitempty,url"`
 
 	// Requested scopes
 	Scopes []string `json:"scopes" mapstructure:"scopes"`
@@ -37,5 +44,14 @@ func (c *ConfigSchema) Validate() error {
 	if err := validate.Struct(c); err != nil {
 		return fmt.Errorf("OAuth2 config validation failed: %w", err)
 	}
+
+	hasAuthority := strings.TrimSpace(c.Authority) != ""
+	hasAuthURL := strings.TrimSpace(c.AuthURL) != ""
+	hasTokenURL := strings.TrimSpace(c.TokenURL) != ""
+
+	if !hasAuthority && !(hasAuthURL && hasTokenURL) {
+		return fmt.Errorf("OAuth2 config validation failed: either authority or both auth_url and token_url must be set")
+	}
+
 	return nil
 }

--- a/internal/providers/oauth2/sessions.go
+++ b/internal/providers/oauth2/sessions.go
@@ -64,7 +64,9 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 		},
 	}
 
-	token, err := conf.Exchange(ctx, authRequest.Code)
+	exchangeContext := context.WithValue(ctx, oauth2.HTTPClient, p.getHTTPClient())
+
+	token, err := conf.Exchange(exchangeContext, authRequest.Code)
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
 	}
@@ -81,7 +83,7 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 			return nil, fmt.Errorf("failed to get user info: no userinfo endpoint configured")
 		}
 
-		userFromEndpoint, endpointErr := getUserInfoFromEndpoint(ctx, userInfoURL, token.AccessToken, resolved.UsernameClaim)
+		userFromEndpoint, endpointErr := getUserInfoFromEndpoint(ctx, p.getHTTPClient(), userInfoURL, token.AccessToken, resolved.UsernameClaim)
 		if endpointErr != nil {
 			return nil, fmt.Errorf("failed to get user info: %w", endpointErr)
 		}
@@ -94,7 +96,7 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 		}
 
 		if userInfoURL != "" {
-			userFromEndpoint, endpointErr := getUserInfoFromEndpoint(ctx, userInfoURL, token.AccessToken, resolved.UsernameClaim)
+			userFromEndpoint, endpointErr := getUserInfoFromEndpoint(ctx, p.getHTTPClient(), userInfoURL, token.AccessToken, resolved.UsernameClaim)
 			if endpointErr == nil && userFromEndpoint != nil && user.Username == "" && userFromEndpoint.Username != "" {
 				// Preserve the ID token as authoritative for the core identity fields and
 				// only enrich the missing username from userinfo when available.
@@ -175,14 +177,14 @@ func getUserInfoFromIDToken(token *oauth2.Token, usernameClaim string) (*models.
 }
 
 // getUserInfoFromEndpoint calls the OIDC userinfo endpoint to get user details.
-func getUserInfoFromEndpoint(ctx context.Context, userInfoURL string, accessToken string, usernameClaim string) (*models.User, error) {
+func getUserInfoFromEndpoint(ctx context.Context, httpClient *http.Client, userInfoURL string, accessToken string, usernameClaim string) (*models.User, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", userInfoURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -212,14 +214,14 @@ func userFromClaims(claims map[string]interface{}, usernameClaim string, subject
 		name = email
 	}
 
-	verified := claimBool(claims, "email_verified")
+	verified := claimOptionalBool(claims, "email_verified")
 
 	return &models.User{
 		ID:       sub,
 		Email:    email,
 		Username: claimUsername(claims, usernameClaim),
 		Name:     name,
-		Verified: &verified,
+		Verified: verified,
 		Source:   "oauth2",
 	}, nil
 }
@@ -247,9 +249,14 @@ func claimString(claims map[string]interface{}, key string) string {
 	return strings.TrimSpace(value)
 }
 
-func claimBool(claims map[string]interface{}, key string) bool {
-	value, _ := claims[key].(bool)
-	return value
+func claimOptionalBool(claims map[string]interface{}, key string) *bool {
+	value, ok := claims[key].(bool)
+	if !ok {
+		return nil
+	}
+
+	result := value
+	return &result
 }
 
 func needsUsernameFallback(user *models.User) bool {

--- a/internal/providers/oauth2/sessions.go
+++ b/internal/providers/oauth2/sessions.go
@@ -70,7 +70,7 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 	}
 
 	// Try to get user info from the ID token first
-	user, err := getUserInfoFromIDToken(token)
+	user, err := getUserInfoFromIDToken(token, resolved.UsernameClaim)
 	if err != nil || user == nil {
 		userInfoURL := resolved.UserInfoURL
 		if userInfoURL == "" {
@@ -81,9 +81,25 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 			return nil, fmt.Errorf("failed to get user info: no userinfo endpoint configured")
 		}
 
-		user, err = getUserInfoFromEndpoint(ctx, userInfoURL, token.AccessToken)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user info: %w", err)
+		userFromEndpoint, endpointErr := getUserInfoFromEndpoint(ctx, userInfoURL, token.AccessToken, resolved.UsernameClaim)
+		if endpointErr != nil {
+			return nil, fmt.Errorf("failed to get user info: %w", endpointErr)
+		}
+
+		user = userFromEndpoint
+	} else if needsUsernameFallback(user) {
+		userInfoURL := resolved.UserInfoURL
+		if userInfoURL == "" {
+			userInfoURL = deriveUserInfoURL(resolved.TokenURL)
+		}
+
+		if userInfoURL != "" {
+			userFromEndpoint, endpointErr := getUserInfoFromEndpoint(ctx, userInfoURL, token.AccessToken, resolved.UsernameClaim)
+			if endpointErr == nil && userFromEndpoint != nil && user.Username == "" && userFromEndpoint.Username != "" {
+				// Preserve the ID token as authoritative for the core identity fields and
+				// only enrich the missing username from userinfo when available.
+				user.Username = userFromEndpoint.Username
+			}
 		}
 	}
 
@@ -134,7 +150,7 @@ func resolveScopes(defaultScopes, requestedScopes []string) []string {
 }
 
 // getUserInfoFromIDToken tries to extract user info from the ID token JWT claims.
-func getUserInfoFromIDToken(token *oauth2.Token) (*models.User, error) {
+func getUserInfoFromIDToken(token *oauth2.Token, usernameClaim string) (*models.User, error) {
 	idToken, ok := token.Extra("id_token").(string)
 	if !ok || idToken == "" {
 		return nil, fmt.Errorf("no id_token in response")
@@ -155,31 +171,11 @@ func getUserInfoFromIDToken(token *oauth2.Token) (*models.User, error) {
 		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
 	}
 
-	sub, _ := claims["sub"].(string)
-	if sub == "" {
-		return nil, fmt.Errorf("no sub claim in JWT")
-	}
-
-	email, _ := claims["email"].(string)
-	name, _ := claims["name"].(string)
-	if name == "" {
-		name = email
-	}
-
-	verifiedRaw, _ := claims["email_verified"].(bool)
-	verified := verifiedRaw
-
-	return &models.User{
-		ID:       sub,
-		Email:    email,
-		Name:     name,
-		Verified: &verified,
-		Source:   "oauth2",
-	}, nil
+	return userFromClaims(claims, usernameClaim)
 }
 
 // getUserInfoFromEndpoint calls the OIDC userinfo endpoint to get user details.
-func getUserInfoFromEndpoint(ctx context.Context, userInfoURL string, accessToken string) (*models.User, error) {
+func getUserInfoFromEndpoint(ctx context.Context, userInfoURL string, accessToken string, usernameClaim string) (*models.User, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", userInfoURL, nil)
 	if err != nil {
 		return nil, err
@@ -201,25 +197,67 @@ func getUserInfoFromEndpoint(ctx context.Context, userInfoURL string, accessToke
 		return nil, err
 	}
 
-	sub, _ := info["sub"].(string)
+	return userFromClaims(info, usernameClaim)
+}
+
+func userFromClaims(claims map[string]interface{}, usernameClaim string) (*models.User, error) {
+	sub, _ := claims["sub"].(string)
 	if sub == "" {
 		return nil, fmt.Errorf("userinfo response missing sub")
 	}
-	email, _ := info["email"].(string)
-	name, _ := info["name"].(string)
+
+	email, _ := claims["email"].(string)
+	name, _ := claims["name"].(string)
 	if name == "" {
 		name = email
 	}
 
-	verified := true
+	verified := claimBool(claims, "email_verified")
 
 	return &models.User{
 		ID:       sub,
 		Email:    email,
+		Username: claimUsername(claims, usernameClaim),
 		Name:     name,
 		Verified: &verified,
 		Source:   "oauth2",
 	}, nil
+}
+
+func claimUsername(claims map[string]interface{}, configuredClaim string) string {
+	for _, claim := range usernameClaimKeys(configuredClaim) {
+		if username := claimString(claims, claim); username != "" {
+			return username
+		}
+	}
+
+	return ""
+}
+
+func usernameClaimKeys(configuredClaim string) []string {
+	if claim := strings.TrimSpace(configuredClaim); claim != "" {
+		return []string{claim}
+	}
+
+	return []string{"preferred_username", "username"}
+}
+
+func claimString(claims map[string]interface{}, key string) string {
+	value, _ := claims[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func claimBool(claims map[string]interface{}, key string) bool {
+	value, _ := claims[key].(bool)
+	return value
+}
+
+func needsUsernameFallback(user *models.User) bool {
+	if user == nil {
+		return true
+	}
+
+	return strings.TrimSpace(user.Username) == ""
 }
 
 func deriveUserInfoURL(tokenURL string) string {

--- a/internal/providers/oauth2/sessions.go
+++ b/internal/providers/oauth2/sessions.go
@@ -171,7 +171,7 @@ func getUserInfoFromIDToken(token *oauth2.Token, usernameClaim string) (*models.
 		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
 	}
 
-	return userFromClaims(claims, usernameClaim)
+	return userFromClaims(claims, usernameClaim, "id_token")
 }
 
 // getUserInfoFromEndpoint calls the OIDC userinfo endpoint to get user details.
@@ -197,13 +197,13 @@ func getUserInfoFromEndpoint(ctx context.Context, userInfoURL string, accessToke
 		return nil, err
 	}
 
-	return userFromClaims(info, usernameClaim)
+	return userFromClaims(info, usernameClaim, "userinfo response")
 }
 
-func userFromClaims(claims map[string]interface{}, usernameClaim string) (*models.User, error) {
+func userFromClaims(claims map[string]interface{}, usernameClaim string, subjectSource string) (*models.User, error) {
 	sub, _ := claims["sub"].(string)
 	if sub == "" {
-		return nil, fmt.Errorf("userinfo response missing sub")
+		return nil, fmt.Errorf("%s missing sub", subjectSource)
 	}
 
 	email, _ := claims["email"].(string)

--- a/internal/providers/oauth2/sessions.go
+++ b/internal/providers/oauth2/sessions.go
@@ -16,33 +16,16 @@ import (
 )
 
 func (p *oauth2Provider) AuthorizeSession(ctx context.Context, authRequest *models.AuthorizeUser) (*models.AuthorizeSessionResponse, error) {
-	schema := &ConfigSchema{}
-	if err := schema.Unmarshal(p.GetConfig()); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal OAuth2 config: %w", err)
+	resolved, err := p.getResolvedConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	scopes := schema.Scopes
-	if len(authRequest.Scopes) > 0 {
-		scopes = authRequest.Scopes
-	}
-	if len(scopes) == 0 {
-		scopes = []string{"openid"}
-	}
-	// Ensure openid scope is always included for OIDC compliance
-	hasOpenID := false
-	for _, s := range scopes {
-		if s == "openid" {
-			hasOpenID = true
-			break
-		}
-	}
-	if !hasOpenID {
-		scopes = append([]string{"openid"}, scopes...)
-	}
+	scopes := resolveScopes(resolved.Scopes, authRequest.Scopes)
 
 	redirectURI := authRequest.RedirectUri
 	if redirectURI == "" {
-		redirectURI = schema.RedirectURL
+		redirectURI = resolved.RedirectURL
 	}
 
 	queryParams := url.Values{
@@ -50,37 +33,34 @@ func (p *oauth2Provider) AuthorizeSession(ctx context.Context, authRequest *mode
 		"response_type": {"code"},
 		"state":         {authRequest.State},
 		"redirect_uri":  {redirectURI},
-		"client_id":     {schema.ClientID},
+		"client_id":     {resolved.ClientID},
 	}
 
-	authURL := fmt.Sprintf("%s?%s", schema.AuthURL, queryParams.Encode())
+	authURL := fmt.Sprintf("%s?%s", resolved.AuthURL, queryParams.Encode())
 	return &models.AuthorizeSessionResponse{Url: authURL}, nil
 }
 
 func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.AuthorizeUser) (*models.Session, error) {
-	schema := &ConfigSchema{}
-	if err := schema.Unmarshal(p.GetConfig()); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal OAuth2 config: %w", err)
+	resolved, err := p.getResolvedConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	scopes := schema.Scopes
-	if len(authRequest.Scopes) > 0 {
-		scopes = authRequest.Scopes
-	}
+	scopes := resolveScopes(resolved.Scopes, authRequest.Scopes)
 
 	redirectURI := authRequest.RedirectUri
 	if redirectURI == "" {
-		redirectURI = schema.RedirectURL
+		redirectURI = resolved.RedirectURL
 	}
 
 	conf := &oauth2.Config{
-		ClientID:     schema.ClientID,
-		ClientSecret: schema.ClientSecret,
+		ClientID:     resolved.ClientID,
+		ClientSecret: resolved.ClientSecret,
 		RedirectURL:  redirectURI,
 		Scopes:       scopes,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  schema.AuthURL,
-			TokenURL: schema.TokenURL,
+			AuthURL:  resolved.AuthURL,
+			TokenURL: resolved.TokenURL,
 		},
 	}
 
@@ -92,8 +72,16 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 	// Try to get user info from the ID token first
 	user, err := getUserInfoFromIDToken(token)
 	if err != nil || user == nil {
-		// Fallback: call userinfo endpoint
-		user, err = getUserInfoFromEndpoint(ctx, schema.TokenURL, token.AccessToken)
+		userInfoURL := resolved.UserInfoURL
+		if userInfoURL == "" {
+			userInfoURL = deriveUserInfoURL(resolved.TokenURL)
+		}
+
+		if userInfoURL == "" {
+			return nil, fmt.Errorf("failed to get user info: no userinfo endpoint configured")
+		}
+
+		user, err = getUserInfoFromEndpoint(ctx, userInfoURL, token.AccessToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get user info: %w", err)
 		}
@@ -125,6 +113,24 @@ func (p *oauth2Provider) CreateSession(ctx context.Context, authRequest *models.
 	})
 
 	return &session, nil
+}
+
+func resolveScopes(defaultScopes, requestedScopes []string) []string {
+	scopes := append([]string(nil), defaultScopes...)
+	if len(requestedScopes) > 0 {
+		scopes = append([]string(nil), requestedScopes...)
+	}
+	if len(scopes) == 0 {
+		scopes = []string{"openid"}
+	}
+
+	for _, scope := range scopes {
+		if scope == "openid" {
+			return scopes
+		}
+	}
+
+	return append([]string{"openid"}, scopes...)
 }
 
 // getUserInfoFromIDToken tries to extract user info from the ID token JWT claims.
@@ -173,11 +179,7 @@ func getUserInfoFromIDToken(token *oauth2.Token) (*models.User, error) {
 }
 
 // getUserInfoFromEndpoint calls the OIDC userinfo endpoint to get user details.
-func getUserInfoFromEndpoint(ctx context.Context, tokenURL string, accessToken string) (*models.User, error) {
-	// Derive userinfo URL from token URL (OIDC standard convention)
-	// e.g., .../protocol/openid-connect/token -> .../protocol/openid-connect/userinfo
-	userInfoURL := strings.Replace(tokenURL, "/token", "/userinfo", 1)
-
+func getUserInfoFromEndpoint(ctx context.Context, userInfoURL string, accessToken string) (*models.User, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", userInfoURL, nil)
 	if err != nil {
 		return nil, err
@@ -200,6 +202,9 @@ func getUserInfoFromEndpoint(ctx context.Context, tokenURL string, accessToken s
 	}
 
 	sub, _ := info["sub"].(string)
+	if sub == "" {
+		return nil, fmt.Errorf("userinfo response missing sub")
+	}
 	email, _ := info["email"].(string)
 	name, _ := info["name"].(string)
 	if name == "" {
@@ -215,6 +220,45 @@ func getUserInfoFromEndpoint(ctx context.Context, tokenURL string, accessToken s
 		Verified: &verified,
 		Source:   "oauth2",
 	}, nil
+}
+
+func deriveUserInfoURL(tokenURL string) string {
+	if tokenURL == "" {
+		return ""
+	}
+
+	parsedURL, err := url.Parse(tokenURL)
+	if err != nil {
+		return ""
+	}
+
+	path := parsedURL.Path
+	if path == "" {
+		return ""
+	}
+
+	hasTrailingSlash := strings.HasSuffix(path, "/")
+	trimmedPath := strings.TrimSuffix(path, "/")
+	lastSlash := strings.LastIndex(trimmedPath, "/")
+
+	lastSegment := trimmedPath
+	if lastSlash >= 0 {
+		lastSegment = trimmedPath[lastSlash+1:]
+	}
+	if lastSegment != "token" {
+		return ""
+	}
+
+	if lastSlash >= 0 {
+		parsedURL.Path = trimmedPath[:lastSlash+1] + "userinfo"
+	} else {
+		parsedURL.Path = "userinfo"
+	}
+	if hasTrailingSlash {
+		parsedURL.Path += "/"
+	}
+
+	return parsedURL.String()
 }
 
 func (p *oauth2Provider) ValidateSession(ctx context.Context, session *models.Session) error {

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -1,0 +1,773 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/thand-io/agent/internal/models"
+)
+
+func TestConfigSchemaValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		schema  ConfigSchema
+		wantErr bool
+	}{
+		{
+			name: "valid with authority only",
+			schema: ConfigSchema{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				Authority:    "https://issuer.example.com",
+			},
+		},
+		{
+			name: "valid with explicit endpoints only",
+			schema: ConfigSchema{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				AuthURL:      "https://issuer.example.com/auth",
+				TokenURL:     "https://issuer.example.com/token",
+			},
+		},
+		{
+			name: "invalid with neither authority nor explicit endpoints",
+			schema: ConfigSchema{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.schema.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeDiscoveryURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		authority string
+		want      string
+	}{
+		{
+			name:      "issuer base URL gets well-known suffix",
+			authority: "https://issuer.example.com/realm/test",
+			want:      "https://issuer.example.com/realm/test/.well-known/openid-configuration",
+		},
+		{
+			name:      "existing well-known URL is preserved",
+			authority: "https://issuer.example.com/.well-known/openid-configuration",
+			want:      "https://issuer.example.com/.well-known/openid-configuration",
+		},
+		{
+			name:      "query and fragment are preserved on issuer URL",
+			authority: "https://issuer.example.com/realm/test?foo=bar#frag",
+			want:      "https://issuer.example.com/realm/test/.well-known/openid-configuration?foo=bar#frag",
+		},
+		{
+			name:      "query and fragment are preserved on discovery URL",
+			authority: "https://issuer.example.com/.well-known/openid-configuration/?foo=bar#frag",
+			want:      "https://issuer.example.com/.well-known/openid-configuration?foo=bar#frag",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeDiscoveryURL(tc.authority); got != tc.want {
+				t.Fatalf("normalizeDiscoveryURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolvedConfigUsesDiscoveryAndExplicitOverrides(t *testing.T) {
+	var mu sync.Mutex
+	discoveryHits := 0
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			mu.Lock()
+			discoveryHits++
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/discovered/auth",
+				"token_endpoint":         server.URL + "/discovered/token",
+				"userinfo_endpoint":      server.URL + "/discovered/userinfo",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"auth_url":      server.URL + "/explicit/auth",
+		"token_url":     server.URL + "/explicit/token",
+		"userinfo_url":  server.URL + "/explicit/userinfo",
+	})
+
+	resolved, err := provider.getResolvedConfig(context.Background())
+	if err != nil {
+		t.Fatalf("resolve config: %v", err)
+	}
+	if resolved.AuthURL != server.URL+"/explicit/auth" {
+		t.Fatalf("expected explicit auth_url override, got %q", resolved.AuthURL)
+	}
+	if resolved.TokenURL != server.URL+"/explicit/token" {
+		t.Fatalf("expected explicit token_url override, got %q", resolved.TokenURL)
+	}
+	if resolved.UserInfoURL != server.URL+"/explicit/userinfo" {
+		t.Fatalf("expected explicit userinfo_url override, got %q", resolved.UserInfoURL)
+	}
+
+	_, err = provider.getResolvedConfig(context.Background())
+	if err != nil {
+		t.Fatalf("resolve cached config: %v", err)
+	}
+
+	mu.Lock()
+	gotDiscoveryHits := discoveryHits
+	mu.Unlock()
+	if gotDiscoveryHits != 0 {
+		t.Fatalf("expected explicit endpoints to skip discovery, got %d discovery fetches", gotDiscoveryHits)
+	}
+}
+
+func TestResolvedConfigUsesDiscoveryForMissingOverrides(t *testing.T) {
+	var mu sync.Mutex
+	discoveryHits := 0
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			mu.Lock()
+			discoveryHits++
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/discovered/auth",
+				"token_endpoint":         server.URL + "/discovered/token",
+				"userinfo_endpoint":      server.URL + "/discovered/userinfo",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"token_url":     server.URL + "/explicit/token",
+	})
+
+	resolved, err := provider.getResolvedConfig(context.Background())
+	if err != nil {
+		t.Fatalf("resolve config: %v", err)
+	}
+	if resolved.AuthURL != server.URL+"/discovered/auth" {
+		t.Fatalf("expected discovered auth_url, got %q", resolved.AuthURL)
+	}
+	if resolved.TokenURL != server.URL+"/explicit/token" {
+		t.Fatalf("expected explicit token_url override, got %q", resolved.TokenURL)
+	}
+	if resolved.UserInfoURL != server.URL+"/discovered/userinfo" {
+		t.Fatalf("expected discovered userinfo_url, got %q", resolved.UserInfoURL)
+	}
+
+	mu.Lock()
+	gotDiscoveryHits := discoveryHits
+	mu.Unlock()
+	if gotDiscoveryHits != 1 {
+		t.Fatalf("expected discovery to be fetched once for missing overrides, got %d", gotDiscoveryHits)
+	}
+}
+
+func TestResolvedConfigSerializesConcurrentDiscovery(t *testing.T) {
+	var mu sync.Mutex
+	discoveryHits := 0
+	firstRequest := make(chan struct{}, 1)
+	releaseDiscovery := make(chan struct{})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != oidcDiscoveryPath {
+			http.NotFound(w, r)
+			return
+		}
+
+		mu.Lock()
+		discoveryHits++
+		currentHits := discoveryHits
+		mu.Unlock()
+
+		if currentHits == 1 {
+			firstRequest <- struct{}{}
+		}
+
+		<-releaseDiscovery
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization_endpoint": server.URL + "/discovered/auth",
+			"token_endpoint":         server.URL + "/discovered/token",
+			"userinfo_endpoint":      server.URL + "/discovered/userinfo",
+		})
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+	})
+
+	const callers = 16
+	errs := make(chan error, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := provider.getResolvedConfig(context.Background())
+			errs <- err
+		}()
+	}
+
+	close(start)
+	<-firstRequest
+	time.Sleep(100 * time.Millisecond)
+	close(releaseDiscovery)
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("resolve config: %v", err)
+		}
+	}
+
+	mu.Lock()
+	gotDiscoveryHits := discoveryHits
+	mu.Unlock()
+	if gotDiscoveryHits != 1 {
+		t.Fatalf("expected a single discovery fetch across concurrent callers, got %d", gotDiscoveryHits)
+	}
+}
+
+func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"email_verified": true,
+	})
+	var mu sync.Mutex
+	var unexpectedTokenPath string
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			mu.Lock()
+			unexpectedTokenPath = r.URL.Path
+			mu.Unlock()
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "very-large-access-token",
+			"refresh_token": "very-large-refresh-token",
+			"id_token":      idToken,
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	cfg := models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      tokenServer.URL + "/auth",
+		"token_url":     tokenServer.URL + "/token",
+		"scopes":        []string{"openid", "profile", "email"},
+	}
+
+	provider := &oauth2Provider{}
+	err := provider.Initialize("oauth2-test", models.ProviderConfig{
+		Name:     "OAuth2 Test",
+		Provider: Oauth2ProviderName,
+		Enabled:  true,
+		Config:   &cfg,
+	})
+	if err != nil {
+		t.Fatalf("initialize provider: %v", err)
+	}
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	mu.Lock()
+	gotUnexpectedTokenPath := unexpectedTokenPath
+	mu.Unlock()
+	if gotUnexpectedTokenPath != "" {
+		t.Fatalf("unexpected token request path: %s", gotUnexpectedTokenPath)
+	}
+
+	if session == nil {
+		t.Fatal("expected session")
+	}
+
+	if session.User == nil {
+		t.Fatal("expected user")
+	}
+
+	if session.User.Email != "user@example.com" {
+		t.Fatalf("expected user email to be preserved, got %q", session.User.Email)
+	}
+
+	if session.Expiry.IsZero() {
+		t.Fatal("expected expiry to be set")
+	}
+
+	if session.Token != "" {
+		t.Fatalf("expected id token to be omitted, got %q", session.Token)
+	}
+
+	if session.AccessToken != "" {
+		t.Fatalf("expected access token to be omitted, got %q", session.AccessToken)
+	}
+
+	if session.RefreshToken != "" {
+		t.Fatalf("expected refresh token to be omitted, got %q", session.RefreshToken)
+	}
+}
+
+func TestAuthorizeSessionUsesDiscoveredAuthURL(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != oidcDiscoveryPath {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization_endpoint": server.URL + "/authorize",
+			"token_endpoint":         server.URL + "/token",
+			"userinfo_endpoint":      server.URL + "/userinfo",
+		})
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"redirect_url":  "http://localhost/default-callback",
+		"scopes":        []string{"profile", "email"},
+	})
+
+	response, err := provider.AuthorizeSession(context.Background(), &models.AuthorizeUser{
+		State: "state-123",
+	})
+	if err != nil {
+		t.Fatalf("authorize session: %v", err)
+	}
+
+	authURL, err := url.Parse(response.Url)
+	if err != nil {
+		t.Fatalf("parse authorize URL: %v", err)
+	}
+	if authURL.Path != "/authorize" {
+		t.Fatalf("expected discovered authorize path, got %q", authURL.Path)
+	}
+
+	query := authURL.Query()
+	if query.Get("client_id") != "test-client-id" {
+		t.Fatalf("expected client_id query param, got %q", query.Get("client_id"))
+	}
+	if query.Get("redirect_uri") != "http://localhost/default-callback" {
+		t.Fatalf("expected redirect_uri query param, got %q", query.Get("redirect_uri"))
+	}
+	if query.Get("state") != "state-123" {
+		t.Fatalf("expected state query param, got %q", query.Get("state"))
+	}
+	if got := query.Get("scope"); got != "openid profile email" {
+		t.Fatalf("expected openid-prefixed scopes, got %q", got)
+	}
+}
+
+func TestCreateSessionUsesDiscoveredTokenAndUserInfo(t *testing.T) {
+	var mu sync.Mutex
+	requestPaths := make([]string, 0, 3)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestPaths = append(requestPaths, r.URL.Path)
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":   "user-456",
+				"email": "oidc@example.com",
+				"name":  "OIDC User",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"redirect_url":  "http://localhost/callback",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code: "auth-code",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session == nil || session.User == nil {
+		t.Fatal("expected session user")
+	}
+	if session.User.Email != "oidc@example.com" {
+		t.Fatalf("expected userinfo email, got %q", session.User.Email)
+	}
+	if session.Token != "" || session.AccessToken != "" || session.RefreshToken != "" {
+		t.Fatal("expected OAuth tokens to be omitted from stored session")
+	}
+	mu.Lock()
+	gotPaths := append([]string(nil), requestPaths...)
+	mu.Unlock()
+	if len(gotPaths) != 3 {
+		t.Fatalf("expected discovery, token, and userinfo requests, got %v", gotPaths)
+	}
+	if gotPaths[0] != oidcDiscoveryPath || gotPaths[1] != "/token" || gotPaths[2] != "/userinfo" {
+		t.Fatalf("unexpected request order: %v", gotPaths)
+	}
+}
+
+func TestCreateSessionFallsBackToDerivedUserInfoURL(t *testing.T) {
+	var mu sync.Mutex
+	requestPaths := make([]string, 0, 3)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestPaths = append(requestPaths, r.URL.Path)
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/protocol/openid-connect/auth",
+				"token_endpoint":         server.URL + "/protocol/openid-connect/token",
+			})
+		case "/protocol/openid-connect/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/protocol/openid-connect/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":   "user-789",
+				"email": "fallback@example.com",
+				"name":  "Fallback User",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"redirect_url":  "http://localhost/callback",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code: "auth-code",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if session == nil || session.User == nil {
+		t.Fatal("expected session user")
+	}
+	if session.User.Email != "fallback@example.com" {
+		t.Fatalf("expected fallback userinfo email, got %q", session.User.Email)
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), requestPaths...)
+	mu.Unlock()
+	if len(gotPaths) != 3 {
+		t.Fatalf("expected discovery, token, and derived userinfo requests, got %v", gotPaths)
+	}
+	if gotPaths[2] != "/protocol/openid-connect/userinfo" {
+		t.Fatalf("expected derived userinfo path, got %q", gotPaths[2])
+	}
+}
+
+func TestDeriveUserInfoURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		tokenURL string
+		want     string
+	}{
+		{
+			name:     "rewrites terminal token segment",
+			tokenURL: "https://issuer.example.com/protocol/openid-connect/token",
+			want:     "https://issuer.example.com/protocol/openid-connect/userinfo",
+		},
+		{
+			name:     "preserves query fragment and trailing slash",
+			tokenURL: "https://issuer.example.com/token/?a=1#fragment",
+			want:     "https://issuer.example.com/userinfo/?a=1#fragment",
+		},
+		{
+			name:     "returns empty for non-token terminal segment",
+			tokenURL: "https://issuer.example.com/oauth2/access-token",
+			want:     "",
+		},
+		{
+			name:     "returns empty for tokenize path",
+			tokenURL: "https://issuer.example.com/oauth2/tokenize",
+			want:     "",
+		},
+		{
+			name:     "returns empty for missing path",
+			tokenURL: "https://issuer.example.com",
+			want:     "",
+		},
+		{
+			name:     "returns empty for invalid URL",
+			tokenURL: "://bad-url",
+			want:     "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := deriveUserInfoURL(tc.tokenURL); got != tc.want {
+				t.Fatalf("deriveUserInfoURL(%q) = %q, want %q", tc.tokenURL, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateSessionFailsWhenDerivedUserInfoURLIsInvalid(t *testing.T) {
+	var mu sync.Mutex
+	userInfoHits := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/access-token":
+			if r.Method == http.MethodPost {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "access-token",
+					"token_type":   "Bearer",
+					"expires_in":   3600,
+				})
+				return
+			}
+
+			mu.Lock()
+			userInfoHits++
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":   "unexpected-user",
+				"email": "wrong@example.com",
+				"name":  "Wrong User",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      server.URL + "/oauth2/auth",
+		"token_url":     server.URL + "/oauth2/access-token",
+		"redirect_url":  "http://localhost/callback",
+	})
+
+	_, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code: "auth-code",
+	})
+	if err == nil {
+		t.Fatal("expected create session to fail when userinfo URL cannot be derived")
+	}
+	if !strings.Contains(err.Error(), "no userinfo endpoint configured") {
+		t.Fatalf("expected no userinfo endpoint error, got %v", err)
+	}
+
+	mu.Lock()
+	gotUserInfoHits := userInfoHits
+	mu.Unlock()
+	if gotUserInfoHits != 0 {
+		t.Fatalf("expected invalid fallback derivation to avoid userinfo request, got %d calls", gotUserInfoHits)
+	}
+}
+
+func TestCreateSessionRejectsUserInfoWithoutSubject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"email": "missing-sub@example.com",
+				"name":  "Missing Subject",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      server.URL + "/auth",
+		"token_url":     server.URL + "/token",
+		"userinfo_url":  server.URL + "/userinfo",
+		"redirect_url":  "http://localhost/callback",
+	})
+
+	_, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code: "auth-code",
+	})
+	if err == nil {
+		t.Fatal("expected create session to fail when userinfo response is missing sub")
+	}
+	if !strings.Contains(err.Error(), "sub") {
+		t.Fatalf("expected missing sub error, got %v", err)
+	}
+}
+
+func createTestIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	headerBytes, err := json.Marshal(map[string]any{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(headerBytes) +
+		"." + base64.RawURLEncoding.EncodeToString(payloadBytes) +
+		"."
+}
+
+func newTestOAuth2Provider(t *testing.T, cfg models.BasicConfig) *oauth2Provider {
+	t.Helper()
+
+	provider := &oauth2Provider{}
+	err := provider.Initialize("oauth2-test", models.ProviderConfig{
+		Name:     "OAuth2 Test",
+		Provider: Oauth2ProviderName,
+		Enabled:  true,
+		Config:   &cfg,
+	})
+	if err != nil {
+		t.Fatalf("initialize provider: %v", err)
+	}
+
+	return provider
+}

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/thand-io/agent/internal/models"
+	"golang.org/x/oauth2"
 )
 
 func TestConfigSchemaValidate(t *testing.T) {
@@ -1191,6 +1192,24 @@ func TestCreateSessionRejectsUserInfoWithoutSubject(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "sub") {
 		t.Fatalf("expected missing sub error, got %v", err)
+	}
+}
+
+func TestGetUserInfoFromIDTokenRejectsMissingSubject(t *testing.T) {
+	token := &oauth2.Token{}
+	token = token.WithExtra(map[string]any{
+		"id_token": createTestIDToken(t, map[string]any{
+			"email": "missing-sub@example.com",
+			"name":  "Missing Subject",
+		}),
+	})
+
+	_, err := getUserInfoFromIDToken(token, "")
+	if err == nil {
+		t.Fatal("expected getUserInfoFromIDToken to fail when id_token is missing sub")
+	}
+	if !strings.Contains(err.Error(), "id_token missing sub") {
+		t.Fatalf("expected id_token missing sub error, got %v", err)
 	}
 }
 

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -303,27 +303,29 @@ func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
 		"name":           "Example User",
 		"email_verified": true,
 	})
-	var mu sync.Mutex
-	var unexpectedTokenPath string
 
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/token" {
-			mu.Lock()
-			unexpectedTokenPath = r.URL.Path
-			mu.Unlock()
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "very-large-access-token",
+				"refresh_token": "very-large-refresh-token",
+				"id_token":      idToken,
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":   "user-123",
+				"email": "userinfo@example.com",
+				"name":  "Userinfo User",
+			})
+		default:
 			http.Error(w, "unexpected token request path", http.StatusBadRequest)
-			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token":  "very-large-access-token",
-			"refresh_token": "very-large-refresh-token",
-			"id_token":      idToken,
-			"token_type":    "Bearer",
-			"expires_in":    3600,
-		})
 	}))
 	defer tokenServer.Close()
 
@@ -354,13 +356,6 @@ func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	mu.Lock()
-	gotUnexpectedTokenPath := unexpectedTokenPath
-	mu.Unlock()
-	if gotUnexpectedTokenPath != "" {
-		t.Fatalf("unexpected token request path: %s", gotUnexpectedTokenPath)
-	}
-
 	if session == nil {
 		t.Fatal("expected session")
 	}
@@ -372,21 +367,24 @@ func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
 	if session.User.Email != "user@example.com" {
 		t.Fatalf("expected user email to be preserved, got %q", session.User.Email)
 	}
+	if session.User.Username != "" {
+		t.Fatalf("expected username to be empty when no username claims are present, got %q", session.User.Username)
+	}
 
 	if session.Expiry.IsZero() {
 		t.Fatal("expected expiry to be set")
 	}
 
-	if session.Token != "" {
-		t.Fatalf("expected id token to be omitted, got %q", session.Token)
+	if session.Token == "" {
+		t.Fatal("expected id token to be preserved")
 	}
 
-	if session.AccessToken != "" {
-		t.Fatalf("expected access token to be omitted, got %q", session.AccessToken)
+	if session.AccessToken == "" {
+		t.Fatal("expected access token to be preserved")
 	}
 
-	if session.RefreshToken != "" {
-		t.Fatalf("expected refresh token to be omitted, got %q", session.RefreshToken)
+	if session.RefreshToken == "" {
+		t.Fatal("expected refresh token to be preserved")
 	}
 }
 
@@ -503,8 +501,14 @@ func TestCreateSessionUsesDiscoveredTokenAndUserInfo(t *testing.T) {
 	if session.User.Email != "oidc@example.com" {
 		t.Fatalf("expected userinfo email, got %q", session.User.Email)
 	}
-	if session.Token != "" || session.AccessToken != "" || session.RefreshToken != "" {
-		t.Fatal("expected OAuth tokens to be omitted from stored session")
+	if session.AccessToken == "" {
+		t.Fatal("expected access token to be preserved in stored session")
+	}
+	if session.Token != "" {
+		t.Fatalf("expected id token to be empty when token response does not include one, got %q", session.Token)
+	}
+	if session.RefreshToken != "" {
+		t.Fatalf("expected refresh token to be empty when token response does not include one, got %q", session.RefreshToken)
 	}
 	mu.Lock()
 	gotPaths := append([]string(nil), requestPaths...)
@@ -582,6 +586,459 @@ func TestCreateSessionFallsBackToDerivedUserInfoURL(t *testing.T) {
 	}
 	if gotPaths[2] != "/protocol/openid-connect/userinfo" {
 		t.Fatalf("expected derived userinfo path, got %q", gotPaths[2])
+	}
+}
+
+func TestCreateSessionUsesPreferredUsernameByDefault(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":                "user-123",
+		"email":              "user@example.com",
+		"name":               "Example User",
+		"preferred_username": "example-user",
+		"email_verified":     true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      tokenServer.URL + "/auth",
+		"token_url":     tokenServer.URL + "/token",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "example-user" {
+		t.Fatalf("expected preferred_username to populate username, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionUsesUsernameFallbackByDefault(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"username":       "fallback-user",
+		"email_verified": true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      tokenServer.URL + "/auth",
+		"token_url":     tokenServer.URL + "/token",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "fallback-user" {
+		t.Fatalf("expected username fallback claim to populate username, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionUsesConfiguredUsernameClaim(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":                "user-123",
+		"email":              "user@example.com",
+		"name":               "Example User",
+		"preferred_username": "preferred-user",
+		"custom_username":    "custom-user",
+		"email_verified":     true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":      "test-client-id",
+		"client_secret":  "test-client-secret",
+		"auth_url":       tokenServer.URL + "/auth",
+		"token_url":      tokenServer.URL + "/token",
+		"username_claim": "custom_username",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "custom-user" {
+		t.Fatalf("expected configured username claim to populate username, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionFallsBackToUserInfoWhenIDTokenLacksUsername(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"email_verified": true,
+	})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"id_token":     idToken,
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":                "user-123",
+				"email":              "userinfo@example.com",
+				"name":               "Userinfo User",
+				"preferred_username": "userinfo-username",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"redirect_url":  "http://localhost/callback",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{Code: "auth-code"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "userinfo-username" {
+		t.Fatalf("expected userinfo username fallback, got %q", session.User.Username)
+	}
+	if session.User.Email != "user@example.com" {
+		t.Fatalf("expected ID token email to remain authoritative, got %q", session.User.Email)
+	}
+	if session.User.Name != "Example User" {
+		t.Fatalf("expected ID token name to remain authoritative, got %q", session.User.Name)
+	}
+}
+
+func TestCreateSessionFallsBackToConfiguredUsernameClaimFromUserInfoWhenIDTokenLacksUsername(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"email_verified": true,
+	})
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"id_token":     idToken,
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":             "user-123",
+				"email":           "userinfo@example.com",
+				"name":            "Userinfo User",
+				"custom_username": "custom-userinfo",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":      "test-client-id",
+		"client_secret":  "test-client-secret",
+		"authority":      server.URL,
+		"redirect_url":   "http://localhost/callback",
+		"username_claim": "custom_username",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{Code: "auth-code"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "custom-userinfo" {
+		t.Fatalf("expected configured userinfo username fallback, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionUsesUsernameFromUserInfoFallback(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":                "user-456",
+				"email":              "oidc@example.com",
+				"name":               "OIDC User",
+				"preferred_username": "oidc-user",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     server.URL,
+		"redirect_url":  "http://localhost/callback",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code: "auth-code",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "oidc-user" {
+		t.Fatalf("expected userinfo username claim to populate username, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionUsesConfiguredUsernameClaimFromUserInfoFallback(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcDiscoveryPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/userinfo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sub":             "user-456",
+				"email":           "oidc@example.com",
+				"name":            "OIDC User",
+				"custom_username": "custom-oidc-user",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":      "test-client-id",
+		"client_secret":  "test-client-secret",
+		"authority":      server.URL,
+		"redirect_url":   "http://localhost/callback",
+		"username_claim": "custom_username",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code: "auth-code",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "custom-oidc-user" {
+		t.Fatalf("expected configured userinfo username claim to populate username, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionIgnoresBlankConfiguredUsernameClaim(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"custom_claim":   "   ",
+		"email_verified": true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":      "test-client-id",
+		"client_secret":  "test-client-secret",
+		"auth_url":       tokenServer.URL + "/auth",
+		"token_url":      tokenServer.URL + "/token",
+		"username_claim": "custom_claim",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "" {
+		t.Fatalf("expected blank configured username claim to be ignored, got %q", session.User.Username)
+	}
+}
+
+func TestCreateSessionIgnoresNonStringConfiguredUsernameClaim(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"custom_claim":   42,
+		"email_verified": true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":      "test-client-id",
+		"client_secret":  "test-client-secret",
+		"auth_url":       tokenServer.URL + "/auth",
+		"token_url":      tokenServer.URL + "/token",
+		"username_claim": "custom_claim",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "" {
+		t.Fatalf("expected non-string configured username claim to be ignored, got %q", session.User.Username)
 	}
 }
 

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -4,17 +4,24 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/thand-io/agent/internal/models"
 	"golang.org/x/oauth2"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestConfigSchemaValidate(t *testing.T) {
 	t.Parallel()
@@ -263,6 +270,8 @@ func TestResolvedConfigSerializesConcurrentDiscovery(t *testing.T) {
 	const callers = 16
 	errs := make(chan error, callers)
 	start := make(chan struct{})
+	ready := make(chan struct{}, callers)
+	proceed := make(chan struct{})
 	var wg sync.WaitGroup
 
 	for range callers {
@@ -270,14 +279,19 @@ func TestResolvedConfigSerializesConcurrentDiscovery(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
+			ready <- struct{}{}
+			<-proceed
 			_, err := provider.getResolvedConfig(context.Background())
 			errs <- err
 		}()
 	}
 
 	close(start)
+	for range callers {
+		<-ready
+	}
+	close(proceed)
 	<-firstRequest
-	time.Sleep(100 * time.Millisecond)
 	close(releaseDiscovery)
 
 	wg.Wait()
@@ -297,7 +311,7 @@ func TestResolvedConfigSerializesConcurrentDiscovery(t *testing.T) {
 	}
 }
 
-func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
+func TestCreateSessionUsesIDTokenClaims(t *testing.T) {
 	idToken := createTestIDToken(t, map[string]any{
 		"sub":            "user-123",
 		"email":          "user@example.com",
@@ -371,6 +385,9 @@ func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
 	if session.User.Username != "" {
 		t.Fatalf("expected username to be empty when no username claims are present, got %q", session.User.Username)
 	}
+	if session.User.Verified == nil || !*session.User.Verified {
+		t.Fatalf("expected verified=true from id token claim, got %#v", session.User.Verified)
+	}
 
 	if session.Expiry.IsZero() {
 		t.Fatal("expected expiry to be set")
@@ -386,6 +403,117 @@ func TestCreateSessionUsesIDTokenClaimsAndOmitsOAuthTokens(t *testing.T) {
 
 	if session.RefreshToken == "" {
 		t.Fatal("expected refresh token to be preserved")
+	}
+}
+
+func TestCreateSessionUsesHardenedClientForTokenExchange(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":            "user-123",
+		"email":          "user@example.com",
+		"name":           "Example User",
+		"email_verified": true,
+	})
+
+	requests := make(chan *http.Request, 1)
+	testHTTPClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			select {
+			case requests <- req:
+			default:
+			}
+
+			body := io.NopCloser(strings.NewReader(`{
+				"access_token":"access-token",
+				"refresh_token":"refresh-token",
+				"id_token":` + strconv.Quote(idToken) + `,
+				"token_type":"Bearer",
+				"expires_in":3600
+			}`))
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		}),
+	}
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      "https://issuer.example.com/auth",
+		"token_url":     "https://issuer.example.com/token",
+	})
+	provider.httpClient = testHTTPClient
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session == nil || session.User == nil {
+		t.Fatal("expected session user")
+	}
+
+	select {
+	case req := <-requests:
+		if req.URL.String() != "https://issuer.example.com/token" {
+			t.Fatalf("expected token exchange request to use configured token URL, got %q", req.URL.String())
+		}
+	default:
+		t.Fatal("expected token exchange to use provider http client")
+	}
+}
+
+func TestResolvedConfigUsesProviderScopedHTTPClient(t *testing.T) {
+	requests := make(chan *http.Request, 1)
+	testHTTPClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			select {
+			case requests <- req:
+			default:
+			}
+
+			body := io.NopCloser(strings.NewReader(`{
+				"authorization_endpoint":"https://issuer.example.com/auth",
+				"token_endpoint":"https://issuer.example.com/token",
+				"userinfo_endpoint":"https://issuer.example.com/userinfo"
+			}`))
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		}),
+	}
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"authority":     "https://issuer.example.com",
+	})
+	provider.httpClient = testHTTPClient
+
+	resolved, err := provider.getResolvedConfig(context.Background())
+	if err != nil {
+		t.Fatalf("resolve config: %v", err)
+	}
+
+	if resolved.AuthURL != "https://issuer.example.com/auth" {
+		t.Fatalf("expected discovered auth_url, got %q", resolved.AuthURL)
+	}
+
+	select {
+	case req := <-requests:
+		if req.URL.String() != "https://issuer.example.com/.well-known/openid-configuration" {
+			t.Fatalf("expected discovery request to use normalized authority URL, got %q", req.URL.String())
+		}
+	default:
+		t.Fatal("expected discovery to use provider http client")
 	}
 }
 
@@ -502,6 +630,9 @@ func TestCreateSessionUsesDiscoveredTokenAndUserInfo(t *testing.T) {
 	if session.User.Email != "oidc@example.com" {
 		t.Fatalf("expected userinfo email, got %q", session.User.Email)
 	}
+	if session.User.Verified != nil {
+		t.Fatalf("expected verified to remain nil when userinfo omits email_verified, got %#v", session.User.Verified)
+	}
 	if session.AccessToken == "" {
 		t.Fatal("expected access token to be preserved in stored session")
 	}
@@ -519,6 +650,49 @@ func TestCreateSessionUsesDiscoveredTokenAndUserInfo(t *testing.T) {
 	}
 	if gotPaths[0] != oidcDiscoveryPath || gotPaths[1] != "/token" || gotPaths[2] != "/userinfo" {
 		t.Fatalf("unexpected request order: %v", gotPaths)
+	}
+}
+
+func TestCreateSessionLeavesVerifiedNilWhenIDTokenOmitsEmailVerified(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":   "user-123",
+		"email": "user@example.com",
+		"name":  "Example User",
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      tokenServer.URL + "/auth",
+		"token_url":     tokenServer.URL + "/token",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Verified != nil {
+		t.Fatalf("expected verified to remain nil when id token omits email_verified, got %#v", session.User.Verified)
 	}
 }
 

--- a/internal/providers/oauth2/sessions_test.go
+++ b/internal/providers/oauth2/sessions_test.go
@@ -809,6 +809,51 @@ func TestCreateSessionUsesPreferredUsernameByDefault(t *testing.T) {
 	}
 }
 
+func TestCreateSessionUsesEmailShapedPreferredUsernameByDefault(t *testing.T) {
+	idToken := createTestIDToken(t, map[string]any{
+		"sub":                "user-123",
+		"email":              "testuser@thand.io",
+		"name":               "Test User",
+		"preferred_username": "testuser@thand.io",
+		"email_verified":     true,
+	})
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.Error(w, "unexpected token request path", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-token",
+			"id_token":     idToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := newTestOAuth2Provider(t, models.BasicConfig{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"auth_url":      tokenServer.URL + "/auth",
+		"token_url":     tokenServer.URL + "/token",
+	})
+
+	session, err := provider.CreateSession(context.Background(), &models.AuthorizeUser{
+		Code:        "test-auth-code",
+		RedirectUri: "http://localhost/callback",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if session.User.Username != "testuser@thand.io" {
+		t.Fatalf("expected email-shaped preferred_username to populate username unchanged, got %q", session.User.Username)
+	}
+}
+
 func TestCreateSessionUsesUsernameFallbackByDefault(t *testing.T) {
 	idToken := createTestIDToken(t, map[string]any{
 		"sub":            "user-123",

--- a/test/integration/frontend/browser.go
+++ b/test/integration/frontend/browser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
+	"github.com/thand-io/agent/test/integration/testinfra"
 )
 
 // Browser represents a chromedp browser automation instance
@@ -38,6 +39,7 @@ func NewBrowser(t *testing.T, baseURL string) *Browser {
 		chromedp.Flag("disable-gpu", false),
 		chromedp.Flag("no-sandbox", true),
 		chromedp.Flag("disable-dev-shm-usage", true),
+		chromedp.Flag("host-resolver-rules", fmt.Sprintf("MAP %s 127.0.0.1", testinfra.KeycloakSharedHostname)),
 	)
 
 	// If CHROME_BIN is set (e.g., in CI environments), use it
@@ -495,7 +497,6 @@ func (b *Browser) WaitForWorkflowCompletion(ctx context.Context, workflowID stri
 }
 
 // ClickApproveButton navigates to the execution page and clicks the Approve button.
-// The button triggers a native confirm() dialog which is auto-accepted via a CDP listener.
 func (b *Browser) ClickApproveButton(ctx context.Context, workflowID string) error {
 	b.t.Log("Clicking approve button in execution UI...")
 
@@ -509,18 +510,10 @@ func (b *Browser) ClickApproveButton(ctx context.Context, workflowID string) err
 		return fmt.Errorf("failed to navigate to execution page: %w", err)
 	}
 
-	// Register a listener that auto-accepts the native confirm() dialog that
-	// signalApproval() shows before calling the approvals API.
-	chromedp.ListenTarget(chromedpCtx, func(ev interface{}) {
-		if _, ok := ev.(*page.EventJavascriptDialogOpening); ok {
-			b.t.Log("Auto-accepting confirm() dialog for approval")
-			go func() {
-				if err := chromedp.Run(chromedpCtx, page.HandleJavaScriptDialog(true)); err != nil {
-					b.t.Logf("Warning: failed to handle dialog: %v", err)
-				}
-			}()
-		}
-	})
+	// Avoid dialog timing races by making the execution page auto-accept confirm().
+	if err := chromedp.Run(chromedpCtx, chromedp.Evaluate(`window.confirm = () => true`, nil)); err != nil {
+		return fmt.Errorf("failed to stub approval confirm dialog: %w", err)
+	}
 
 	// Wait for the Alpine.js-rendered Approve button to appear, then click it.
 	// The button is inside an x-if block and only shows when the current task is 'approvals'.
@@ -702,28 +695,37 @@ func extractWorkflowIDFromURL(rawURL string) string {
 	return ""
 }
 
-// ApproveAsManager creates a separate browser session, logs in as the manager,
+// ApproveAsUser creates a separate browser session, logs in as the given user,
 // navigates to the workflow execution, and clicks approve.
-func (b *Browser) ApproveAsManager(
+func (b *Browser) ApproveAsUser(
 	ctx context.Context,
-
-	managerUsername, managerPassword, workflowID string,
+	username, password, workflowID string,
 ) error {
-	b.t.Log("Manager approving workflow...")
+	approver := NewBrowser(b.t, b.baseURL)
+	defer approver.Close()
 
-	// Create a new browser session for the manager
-	manager := NewBrowser(b.t, b.baseURL)
-	defer manager.Close()
-
-	// Login as manager
-	if err := manager.Login(ctx, managerUsername, managerPassword); err != nil {
-		return fmt.Errorf("manager login failed: %w", err)
+	if err := approver.Login(ctx, username, password); err != nil {
+		return fmt.Errorf("approver login failed: %w", err)
 	}
 
 	time.Sleep(2 * time.Second)
 
-	// Click approve
-	if err := manager.ClickApproveButton(ctx, workflowID); err != nil {
+	if err := approver.ClickApproveButton(ctx, workflowID); err != nil {
+		return fmt.Errorf("approval failed: %w", err)
+	}
+
+	return nil
+}
+
+// ApproveAsManager creates a separate browser session, logs in as the manager,
+// navigates to the workflow execution, and clicks approve.
+func (b *Browser) ApproveAsManager(
+	ctx context.Context,
+	managerUsername, managerPassword, workflowID string,
+) error {
+	b.t.Log("Manager approving workflow...")
+
+	if err := b.ApproveAsUser(ctx, managerUsername, managerPassword, workflowID); err != nil {
 		return fmt.Errorf("manager approval failed: %w", err)
 	}
 
@@ -732,7 +734,6 @@ func (b *Browser) ApproveAsManager(
 }
 
 // ClickDenyButton navigates to the execution page and clicks the Reject button.
-// The button triggers a native confirm() dialog which is auto-accepted via a CDP listener.
 func (b *Browser) ClickDenyButton(ctx context.Context, workflowID string) error {
 	b.t.Log("Clicking reject button in execution UI...")
 
@@ -746,17 +747,10 @@ func (b *Browser) ClickDenyButton(ctx context.Context, workflowID string) error 
 		return fmt.Errorf("failed to navigate to execution page: %w", err)
 	}
 
-	// Register a listener that auto-accepts the confirm() dialog.
-	chromedp.ListenTarget(chromedpCtx, func(ev interface{}) {
-		if _, ok := ev.(*page.EventJavascriptDialogOpening); ok {
-			b.t.Log("Auto-accepting confirm() dialog for rejection")
-			go func() {
-				if err := chromedp.Run(chromedpCtx, page.HandleJavaScriptDialog(true)); err != nil {
-					b.t.Logf("Warning: failed to handle dialog: %v", err)
-				}
-			}()
-		}
-	})
+	// Avoid dialog timing races by making the execution page auto-accept confirm().
+	if err := chromedp.Run(chromedpCtx, chromedp.Evaluate(`window.confirm = () => true`, nil)); err != nil {
+		return fmt.Errorf("failed to stub rejection confirm dialog: %w", err)
+	}
 
 	// Poll for the Alpine.js-rendered Reject button (button-destructive, text "Reject").
 	clickRejectJS := `(function() {

--- a/test/integration/frontend/elevation_e2e_test.go
+++ b/test/integration/frontend/elevation_e2e_test.go
@@ -44,7 +44,9 @@ func TestElevationE2E(t *testing.T) {
 	for _, tcName := range testCases {
 		tcName := tcName // capture range variable
 		t.Run(tcName, func(t *testing.T) {
-			t.Parallel()
+			// These UI cases authenticate back to localhost-based Thand instances.
+			// Running them in parallel causes browser cookie collisions because
+			// cookies are scoped by host, not port.
 			runElevationE2E(t, tcName)
 		})
 	}
@@ -227,7 +229,8 @@ func runElevationE2E(t *testing.T, testCaseName string) {
 			require.NoError(t, err, "Manager should be able to approve")
 		} else {
 			t.Log("Self-approving the request...")
-			err = browser.ClickApproveButton(ctx, workflowID)
+			err = browser.ApproveAsUser(ctx,
+				requestUser.Username, requestUser.Password, workflowID)
 			require.NoError(t, err, "Should be able to self-approve")
 		}
 

--- a/test/integration/frontend/infrastructure_test.go
+++ b/test/integration/frontend/infrastructure_test.go
@@ -130,7 +130,6 @@ func (infra *UITestInfrastructure) createConfigDir(t *testing.T, testCase *TestC
 	// Compute endpoint values and store them for injection into the server container.
 	// ResolveConfig reads os.Environ() and resolves ${ .VARNAME } jq expressions in YAML files.
 	// host.docker.internal URLs are server-side (inside container).
-	// localhost URLs are browser-facing (navigated by the test's chromedp browser).
 	temporalEndpointInternal := strings.ReplaceAll(infra.TestInfrastructure.TemporalEndpoint, "localhost", "host.docker.internal")
 
 	infra.providerEnvVars = map[string]string{
@@ -141,12 +140,11 @@ func (infra *UITestInfrastructure) createConfigDir(t *testing.T, testCase *TestC
 	}
 
 	if infra.TestInfrastructure.KeycloakEndpoint != "" {
-		oidcIssuerBrowser := infra.TestInfrastructure.KeycloakOIDCIssuerURL() // already localhost
-		oidcIssuerInternal := strings.ReplaceAll(oidcIssuerBrowser, "localhost", "host.docker.internal")
+		oidcIssuer := infra.TestInfrastructure.KeycloakOIDCIssuerURL()
 		samlMetaBrowser := infra.TestInfrastructure.KeycloakSAMLMetadataURL()
 		samlMetaInternal := strings.ReplaceAll(samlMetaBrowser, "localhost", "host.docker.internal")
-		infra.providerEnvVars["OIDC_ISSUER_URL"] = oidcIssuerBrowser
-		infra.providerEnvVars["OIDC_ISSUER_URL_INTERNAL"] = oidcIssuerInternal
+		infra.providerEnvVars["OIDC_ISSUER_URL"] = oidcIssuer
+		infra.providerEnvVars["OIDC_ISSUER_URL_INTERNAL"] = oidcIssuer
 		infra.providerEnvVars["SAML_IDP_METADATA_URL"] = samlMetaBrowser
 		infra.providerEnvVars["SAML_IDP_METADATA_URL_INTERNAL"] = samlMetaInternal
 	}
@@ -312,7 +310,10 @@ workflows:
 				},
 			}
 			// Ensure host.docker.internal resolves on Linux Docker (not only Docker Desktop).
-			hc.ExtraHosts = []string{"host.docker.internal:host-gateway"}
+			hc.ExtraHosts = []string{
+				"host.docker.internal:host-gateway",
+				testinfra.KeycloakSharedHostname + ":host-gateway",
+			}
 		},
 		WaitingFor: wait.ForListeningPort(ThandServerPort + "/tcp").
 			WithStartupTimeout(120 * time.Second),

--- a/test/integration/testinfra/infrastructure.go
+++ b/test/integration/testinfra/infrastructure.go
@@ -22,7 +22,9 @@ import (
 	"github.com/thand-io/agent/internal/common"
 	sdkConstants "github.com/thand-io/agent/sdk/constants"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"go.temporal.io/api/enums/v1"
@@ -370,6 +372,7 @@ system.forceSearchAttributesCacheRefreshOnRead:
 		Env: map[string]string{
 			"DB":                       "postgres12",
 			"DB_PORT":                  "5432",
+			"BIND_ON_IP":               "0.0.0.0",
 			"POSTGRES_USER":            "temporal",
 			"POSTGRES_PWD":             "temporal",
 			"POSTGRES_SEEDS":           postgresIP,
@@ -491,7 +494,7 @@ func (infra *TestInfrastructure) registerNamespaceWithSearchAttributes(ctx conte
 	workflowClient := workflowservice.NewWorkflowServiceClient(conn)
 	operatorClient := operatorservice.NewOperatorServiceClient(conn)
 
-	// Register the namespace
+	// Register the namespace directly. Unexpected bootstrap failures should fail fast.
 	_, err = workflowClient.RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        TemporalTestNamespace,
 		Description:                      "Integration test namespace for thand agent",
@@ -522,10 +525,14 @@ func (infra *TestInfrastructure) registerNamespaceWithSearchAttributes(ctx conte
 		searchAttributes[attr.GetName()] = attr.GetValueType()
 	}
 
-	// Add all search attributes in a single call
-	_, err = operatorClient.AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
-		Namespace:        TemporalTestNamespace,
-		SearchAttributes: searchAttributes,
+	// Temporal can briefly lag namespace visibility after registration, so allow a
+	// short retry window for this follow-up call only.
+	err = retryAddSearchAttributesUntilNamespaceVisible(ctx, func(callCtx context.Context) error {
+		_, err := operatorClient.AddSearchAttributes(callCtx, &operatorservice.AddSearchAttributesRequest{
+			Namespace:        TemporalTestNamespace,
+			SearchAttributes: searchAttributes,
+		})
+		return err
 	})
 	require.NoError(infra.t, err, "Failed to add search attributes to namespace")
 
@@ -544,6 +551,45 @@ func (infra *TestInfrastructure) TemporalHostPort() (string, int) {
 	port := 7233
 	fmt.Sscanf(portStr, "%d", &port)
 	return host, port
+}
+
+func retryAddSearchAttributesUntilNamespaceVisible(ctx context.Context, op func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	const (
+		pollInterval = 250 * time.Millisecond
+		rpcTimeout   = 3 * time.Second
+	)
+
+	var lastErr error
+	for {
+		callCtx, callCancel := context.WithTimeout(ctx, rpcTimeout)
+		lastErr = op(callCtx)
+		callCancel()
+		if lastErr == nil {
+			return nil
+		}
+
+		if !isNamespaceNotVisibleError(lastErr) {
+			return lastErr
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for Temporal namespace visibility: %w", lastErr)
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func isNamespaceNotVisibleError(err error) bool {
+	if status.Code(err) == codes.NotFound {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "namespace") && strings.Contains(message, "not found")
 }
 
 // Testing returns the *testing.T associated with this infrastructure.

--- a/test/integration/testinfra/infrastructure.go
+++ b/test/integration/testinfra/infrastructure.go
@@ -63,8 +63,10 @@ type TestInfrastructure struct {
 	TemporalClient    client.Client
 
 	// Keycloak (Identity Provider - optional)
-	keycloakContainer testcontainers.Container
-	KeycloakEndpoint  string
+	keycloakContainer     testcontainers.Container
+	KeycloakEndpoint      string
+	KeycloakAdvertisedURL string
+	allocatedKeycloakPort int
 
 	// Cleanup callbacks - called before container teardown to gracefully shutdown workers
 	cleanupCallbacks []func()

--- a/test/integration/testinfra/keycloak.go
+++ b/test/integration/testinfra/keycloak.go
@@ -5,8 +5,13 @@ package testinfra
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
 	"time"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -19,10 +24,13 @@ const (
 	KeycloakImage = "quay.io/keycloak/keycloak:26.1"
 	// KeycloakTestRealm is the realm name used for tests.
 	KeycloakTestRealm = "thand-test"
+	// KeycloakSharedHostname is the browser- and container-resolvable hostname used in frontend tests.
+	KeycloakSharedHostname = "keycloak.test"
 	// KeycloakAdminUser is the default admin user for Keycloak.
 	KeycloakAdminUser = "admin"
 	// KeycloakAdminPassword is the default admin password for Keycloak.
 	KeycloakAdminPassword = "admin"
+	keycloakBindMaxAttempts = 5
 )
 
 // startKeycloak starts a Keycloak container with the given realm import file.
@@ -30,57 +38,108 @@ const (
 func (infra *TestInfrastructure) startKeycloak(ctx context.Context, realmFilePath string) {
 	infra.t.Log("Starting Keycloak container...")
 
-	req := testcontainers.ContainerRequest{
-		Image: KeycloakImage,
-		Cmd: []string{
-			"start-dev",
-			"--import-realm",
-			"--health-enabled=true",
-		},
-		ExposedPorts: []string{KeycloakPort + "/tcp"},
-		Env: map[string]string{
-			"KEYCLOAK_ADMIN":          KeycloakAdminUser,
-			"KEYCLOAK_ADMIN_PASSWORD": KeycloakAdminPassword,
-			"KC_HTTP_PORT":            KeycloakPort,
-		},
-		Files: []testcontainers.ContainerFile{
-			{
-				HostFilePath:      realmFilePath,
-				ContainerFilePath: "/opt/keycloak/data/import/thand-test-realm.json",
-				FileMode:          0644,
+	for attempt := 1; attempt <= keycloakBindMaxAttempts; attempt++ {
+		allocatedPort, err := allocateFreeHostPort()
+		require.NoError(infra.t, err, "Failed to allocate a free port for Keycloak")
+
+		advertisedBaseURL := fmt.Sprintf("http://%s:%d", KeycloakSharedHostname, allocatedPort)
+		req := testcontainers.ContainerRequest{
+			Image: KeycloakImage,
+			Cmd: []string{
+				"start-dev",
+				"--import-realm",
+				"--health-enabled=true",
+				"--hostname=" + advertisedBaseURL,
 			},
-		},
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort(KeycloakPort+"/tcp").WithStartupTimeout(120*time.Second),
-			wait.ForHTTP("/realms/"+KeycloakTestRealm+"/.well-known/openid-configuration").
-				WithPort(KeycloakPort+"/tcp").
-				WithStartupTimeout(120*time.Second).
-				WithPollInterval(2*time.Second),
-		).WithDeadline(180 * time.Second),
+			ExposedPorts: []string{KeycloakPort + "/tcp"},
+			Env: map[string]string{
+				"KEYCLOAK_ADMIN":          KeycloakAdminUser,
+				"KEYCLOAK_ADMIN_PASSWORD": KeycloakAdminPassword,
+				"KC_HTTP_PORT":            KeycloakPort,
+			},
+			HostConfigModifier: func(hc *dockercontainer.HostConfig) {
+				hc.PortBindings = nat.PortMap{
+					nat.Port(KeycloakPort + "/tcp"): []nat.PortBinding{
+						{HostIP: "0.0.0.0", HostPort: strconv.Itoa(allocatedPort)},
+					},
+				}
+			},
+			Files: []testcontainers.ContainerFile{
+				{
+					HostFilePath:      realmFilePath,
+					ContainerFilePath: "/opt/keycloak/data/import/thand-test-realm.json",
+					FileMode:          0644,
+				},
+			},
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort(KeycloakPort+"/tcp").WithStartupTimeout(120*time.Second),
+				wait.ForHTTP("/realms/"+KeycloakTestRealm+"/.well-known/openid-configuration").
+					WithPort(KeycloakPort+"/tcp").
+					WithStartupTimeout(120*time.Second).
+					WithPollInterval(2*time.Second),
+			).WithDeadline(180 * time.Second),
+		}
+
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			if attempt < keycloakBindMaxAttempts && isKeycloakBindConflict(err) {
+				infra.t.Logf("Keycloak port %d was claimed before Docker could bind it, retrying (%d/%d): %v", allocatedPort, attempt, keycloakBindMaxAttempts, err)
+				continue
+			}
+			require.NoError(infra.t, err, "Failed to start Keycloak container")
+		}
+
+		infra.keycloakContainer = container
+		infra.allocatedKeycloakPort = allocatedPort
+
+		host, err := container.Host(ctx)
+		require.NoError(infra.t, err, "Failed to get Keycloak host")
+		mappedPort, err := container.MappedPort(ctx, KeycloakPort+"/tcp")
+		require.NoError(infra.t, err, "Failed to get Keycloak port")
+
+		infra.KeycloakEndpoint = fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
+		infra.KeycloakAdvertisedURL = advertisedBaseURL
+		infra.t.Logf("Keycloak started at %s (advertised as %s)", infra.KeycloakEndpoint, infra.KeycloakAdvertisedURL)
+		return
 	}
+}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	require.NoError(infra.t, err, "Failed to start Keycloak container")
-	infra.keycloakContainer = container
+func allocateFreeHostPort() (int, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
 
-	host, err := container.Host(ctx)
-	require.NoError(infra.t, err, "Failed to get Keycloak host")
-	mappedPort, err := container.MappedPort(ctx, KeycloakPort+"/tcp")
-	require.NoError(infra.t, err, "Failed to get Keycloak port")
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
 
-	infra.KeycloakEndpoint = fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
-	infra.t.Logf("Keycloak started at %s", infra.KeycloakEndpoint)
+func isKeycloakBindConflict(err error) bool {
+	message := err.Error()
+	return strings.Contains(message, "port is already allocated") ||
+		strings.Contains(message, "bind: address already in use") ||
+		strings.Contains(message, "Ports are not available")
+}
+
+func (infra *TestInfrastructure) keycloakPublicBaseURL() string {
+	baseURL := infra.KeycloakAdvertisedURL
+	if baseURL == "" {
+		baseURL = infra.KeycloakEndpoint
+	}
+	return baseURL
 }
 
 // KeycloakOIDCIssuerURL returns the OIDC issuer URL for the test realm.
 func (infra *TestInfrastructure) KeycloakOIDCIssuerURL() string {
-	return infra.KeycloakEndpoint + "/realms/" + KeycloakTestRealm
+	baseURL := infra.keycloakPublicBaseURL()
+	return baseURL + "/realms/" + KeycloakTestRealm
 }
 
 // KeycloakSAMLMetadataURL returns the SAML IdP metadata URL for the test realm.
 func (infra *TestInfrastructure) KeycloakSAMLMetadataURL() string {
-	return infra.KeycloakEndpoint + "/realms/" + KeycloakTestRealm + "/protocol/saml/descriptor"
+	baseURL := infra.keycloakPublicBaseURL()
+	return baseURL + "/realms/" + KeycloakTestRealm + "/protocol/saml/descriptor"
 }


### PR DESCRIPTION
## Summary
- add OIDC discovery defaults to the generic `oauth2` provider using `authority` with explicit endpoint overrides
- resolve discovery lazily at runtime and use resolved auth, token, and userinfo endpoints across the session flow
- support configurable username-claim extraction and improve claim parsing/error reporting for ID token and userinfo responses
- harden outbound OAuth/OIDC calls by using a provider-scoped HTTP client for discovery, token exchange, and userinfo
- follow up on review feedback with trailing-slash discovery normalization, docs/schema alignment, and focused oauth2 regression coverage

## Verification
- `go test -count=1 ./internal/providers/oauth2`
- `go test -race -count=1 ./internal/providers/oauth2`
