### PR TITLE
RFC: fix config sync application and retry semantics

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -9,3 +9,12 @@ description: Developer documentation for Thand Agent
 # Development
 
 Documentation for developers contributing to or extending the Thand Agent.
+
+## Config Mutation Invariant
+
+Configuration definition maps should be treated as immutable snapshots.
+When config changes, prefer replacing whole entries or whole definition maps
+instead of mutating nested state in place. Some older code paths still perform
+mutation-prone updates; keep new code aligned with the invariant and track
+cleanup of legacy exceptions in follow-up issues rather than extending them.
+Current cleanup work is tracked in [#306](https://github.com/thand-io/agent/issues/306).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -360,6 +360,7 @@ func (c *Config) ReloadConfig() error {
 			logrus.Infoln("Loaded workflows from external source:", len(workflows))
 			c.mu.Lock()
 			c.Workflows.Definitions = workflows
+			c.configGeneration++
 			c.mu.Unlock()
 		} else {
 			logrus.Warningln("No workflows loaded from external source")
@@ -378,6 +379,7 @@ func (c *Config) ReloadConfig() error {
 			logrus.Infoln("Loaded providers from external source:", len(providers))
 			c.mu.Lock()
 			c.Providers.Definitions = providers
+			c.configGeneration++
 			c.mu.Unlock()
 		} else {
 			logrus.Warningln("No providers loaded from external source")
@@ -394,6 +396,7 @@ func (c *Config) ReloadConfig() error {
 			logrus.Infoln("Loaded roles from external source:", len(roles))
 			c.mu.Lock()
 			c.Roles.Definitions = roles
+			c.configGeneration++
 			c.mu.Unlock()
 		} else {
 			logrus.Warningln("No roles loaded from external source")

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -64,6 +64,12 @@ type Config struct {
 	logger thandLogger
 	mu     sync.RWMutex
 
+	// Incremented whenever synced config definitions actually change.
+	// Definition maps should be treated as immutable snapshots: callers should
+	// replace whole entries or whole maps rather than mutating nested state
+	// in place. Legacy mutation-prone paths are being tracked in issue #306.
+	configGeneration uint64
+
 	// Cached services client
 	initializeServiceClientOnce sync.Once
 	servicesClient              models.ServicesClientImpl

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,6 +12,34 @@ import (
 	"github.com/thand-io/agent/internal/common"
 	"github.com/thand-io/agent/internal/models"
 )
+
+const maxMergeConfigurationRetries = 3
+
+type configPatchSnapshot struct {
+	generation              uint64
+	request                 ConfigPatchRequest
+	data                    []byte
+	roleDefinitionsJSON     []byte
+	workflowDefinitionsJSON []byte
+	providerDefinitionsJSON []byte
+}
+
+type buildMergedConfigResult struct {
+	config        ConfigPatchRequest
+	outgoingPatch []byte
+}
+
+type normalizedDefinitionsPatch struct {
+	roleDefinitions            map[string]models.Role
+	roleDefinitionsJSON        []byte
+	roleDefinitionsChanged     bool
+	workflowDefinitions        map[string]models.Workflow
+	workflowDefinitionsJSON    []byte
+	workflowDefinitionsChanged bool
+	providerDefinitions        map[string]models.ProviderConfig
+	providerDefinitionsJSON    []byte
+	providerDefinitionsChanged bool
+}
 
 type ConfigPatchRequest struct {
 	RoleConfig     *RoleConfig                `json:"roles,omitempty"`
@@ -33,63 +62,41 @@ func (c *Config) MergeConfiguration(config *RegistrationResponse) error {
 		return err
 	}
 
-	roles := c.GetRolesConfig()
-	workflows := c.GetWorkflowsConfig()
-	providers := c.GetProvidersConfig()
+	outgoingPatch, err := c.applyMergedConfigWithRetries(func(snapshot *configPatchSnapshot) (*buildMergedConfigResult, error) {
+		// Apply the incoming changes over the existing configurations.
+		newData, err := jsonpatch.MergePatch(snapshot.data, incomingData)
+		if err != nil {
+			logrus.WithError(err).Errorln("Failed to create merge patch for configuration diffing")
+			return nil, err
+		}
 
-	existing := ConfigPatchRequest{
-		RoleConfig:     roles,
-		WorkflowConfig: workflows,
-		ProviderConfig: providers,
-	}
+		// Convert the merged configuration back to a struct so the in-memory
+		// config reflects the fully merged remote+local state rather than a
+		// sparse diff payload. Unmarshaling the sparse merge patch here would
+		// collapse omitted fields to zero values in typed structs.
+		var mergedConfig ConfigPatchRequest
+		err = json.Unmarshal(newData, &mergedConfig)
+		if err != nil {
+			logrus.WithError(err).Errorln("Failed to unmarshal merged configuration")
+			return nil, err
+		}
 
-	existingData, err := json.Marshal(existing)
+		// Now we need to figure out what changes exist on the local system that need to
+		// be sent back to the server
+		outgoingPatch, err := jsonpatch.CreateMergePatch(incomingData, snapshot.data)
+		if err != nil {
+			logrus.WithError(err).Errorln("Failed to create merge patch for configuration diffing")
+			return nil, err
+		}
 
+		return &buildMergedConfigResult{
+			config:        mergedConfig,
+			outgoingPatch: outgoingPatch,
+		}, nil
+	})
 	if err != nil {
-		logrus.WithError(err).Errorln("Failed to marshal existing configuration for diffing")
 		return err
 	}
-
-	// Apply the incoming changes over the existing configurations
-	newData, err := jsonpatch.MergePatch(existingData, incomingData)
-
-	if err != nil {
-		logrus.WithError(err).Errorln("Failed to create merge patch for configuration diffing")
-		return err
-	}
-
-	// Convert the merged configuration back to a struct so the in-memory
-	// config reflects the fully merged remote+local state rather than a
-	// sparse diff payload. Unmarshaling the sparse merge patch here would
-	// collapse omitted fields to zero values in typed structs.
-	var mergedConfig ConfigPatchRequest
-	err = json.Unmarshal(newData, &mergedConfig)
-
-	if err != nil {
-		logrus.WithError(err).Errorln("Failed to unmarshal merged configuration")
-		return err
-	}
-
-	// Apply the desired end state directly. applyPatch remains the helper for
-	// callers that actually have partial section diffs to merge locally first.
-	err = c.applyMergedConfig(mergedConfig)
-
-	if err != nil {
-		logrus.WithError(err).Errorln("Failed to apply incoming configuration patch")
-		return err
-	}
-
-	// Now we need to figure out what changes exist on the local system that need to
-	// be sent back to the server
-
-	outgoingPatch, err := jsonpatch.CreateMergePatch(incomingData, existingData)
-
-	if err != nil {
-		logrus.WithError(err).Errorln("Failed to create merge patch for configuration diffing")
-		return err
-	}
-
-	// Send the outgoing changes back to the server to update its configuration
 
 	go func() {
 
@@ -133,10 +140,102 @@ func (c *Config) MergeConfiguration(config *RegistrationResponse) error {
 
 }
 
+func (c *Config) applyMergedConfigWithRetries(build func(snapshot *configPatchSnapshot) (*buildMergedConfigResult, error)) ([]byte, error) {
+	for attempt := range maxMergeConfigurationRetries {
+		snapshot, err := c.snapshotConfigPatch()
+		if err != nil {
+			logrus.WithError(err).Errorln("Failed to marshal existing configuration for diffing")
+			return nil, err
+		}
+
+		result, err := build(snapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		applied, err := c.applyMergedConfigWithSnapshot(snapshot, result.config)
+		if err != nil {
+			logrus.WithError(err).Errorln("Failed to apply incoming merged configuration")
+			return nil, err
+		}
+		if applied {
+			return result.outgoingPatch, nil
+		}
+
+		logrus.WithField("attempt", attempt+1).Infoln("Configuration changed during merged sync apply, retrying")
+	}
+
+	logrus.WithField("attempts", maxMergeConfigurationRetries).Warnln("Configuration changed during every merged sync attempt")
+	return nil, fmt.Errorf("configuration changed during merge after %d attempts", maxMergeConfigurationRetries)
+}
+
+func (c *Config) snapshotConfigPatch() (*configPatchSnapshot, error) {
+	c.mu.RLock()
+	snapshot := ConfigPatchRequest{
+		RoleConfig: &RoleConfig{
+			Path:        c.Roles.Path,
+			URL:         c.Roles.URL,
+			Vault:       c.Roles.Vault,
+			Definitions: c.Roles.Definitions,
+		},
+		WorkflowConfig: &WorkflowConfig{
+			Path:        c.Workflows.Path,
+			URL:         c.Workflows.URL,
+			Vault:       c.Workflows.Vault,
+			Plugins:     c.Workflows.Plugins,
+			Definitions: c.Workflows.Definitions,
+		},
+		ProviderConfig: &ProviderDefinitionsConfig{
+			Path:        c.Providers.Path,
+			URL:         c.Providers.URL,
+			Vault:       c.Providers.Vault,
+			Plugins:     c.Providers.Plugins,
+			Definitions: c.Providers.Definitions,
+		},
+	}
+	generation := c.configGeneration
+
+	data, err := json.Marshal(snapshot)
+	c.mu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
+	// Keep sync retries isolated from in-place nested mutations by detaching the
+	// snapshot through the same JSON representation used for merge-patch diffing.
+	var detached ConfigPatchRequest
+	if err := json.Unmarshal(data, &detached); err != nil {
+		return nil, err
+	}
+
+	roleDefinitionsJSON, err := marshalJSON(detachedRoleDefinitions(detached.RoleConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	workflowDefinitionsJSON, err := marshalJSON(detachedWorkflowDefinitions(detached.WorkflowConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	providerDefinitionsJSON, err := marshalJSON(detachedProviderDefinitions(detached.ProviderConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	return &configPatchSnapshot{
+		generation:              generation,
+		request:                 detached,
+		data:                    data,
+		roleDefinitionsJSON:     roleDefinitionsJSON,
+		workflowDefinitionsJSON: workflowDefinitionsJSON,
+		providerDefinitionsJSON: providerDefinitionsJSON,
+	}, nil
+}
+
 func (c *Config) applyPatch(diff ConfigPatchRequest) error {
 	// applyPatch is the partial-patch helper: merge the incoming section diff
 	// with the current live section, then normalize and persist the result.
-	// Apply role changes
 	if diff.RoleConfig != nil {
 		err := c.updateRoles(diff.RoleConfig)
 		if err != nil {
@@ -145,7 +244,6 @@ func (c *Config) applyPatch(diff ConfigPatchRequest) error {
 		}
 	}
 
-	// Apply workflow changes
 	if diff.WorkflowConfig != nil {
 		err := c.updateWorkflows(diff.WorkflowConfig)
 		if err != nil {
@@ -154,7 +252,6 @@ func (c *Config) applyPatch(diff ConfigPatchRequest) error {
 		}
 	}
 
-	// Apply provider changes
 	if diff.ProviderConfig != nil {
 		err := c.updateProviders(diff.ProviderConfig)
 		if err != nil {
@@ -169,28 +266,124 @@ func (c *Config) applyPatch(diff ConfigPatchRequest) error {
 // applyMergedConfig applies a fully merged server state. It normalizes each
 // definitions map and stores it directly without re-merging the same sections.
 func (c *Config) applyMergedConfig(config ConfigPatchRequest) error {
+	snapshot, err := c.snapshotConfigPatch()
+	if err != nil {
+		return err
+	}
+
+	applied, err := c.applyMergedConfigWithSnapshot(snapshot, config)
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return fmt.Errorf("configuration changed while applying merged configuration")
+	}
+
+	return nil
+}
+
+func (c *Config) applyMergedConfigWithSnapshot(snapshot *configPatchSnapshot, config ConfigPatchRequest) (bool, error) {
+	normalized, err := c.normalizeMergedConfig(snapshot, config)
+	if err != nil {
+		return false, err
+	}
+
+	return c.commitMergedDefinitions(normalized, snapshot.generation), nil
+}
+
+func (c *Config) normalizeMergedConfig(snapshot *configPatchSnapshot, config ConfigPatchRequest) (*normalizedDefinitionsPatch, error) {
+	normalized := &normalizedDefinitionsPatch{}
+
 	if config.RoleConfig != nil {
-		if err := c.storeRoleDefinitions(config.RoleConfig.Definitions); err != nil {
-			logrus.WithError(err).Errorln("Failed to apply merged role configuration")
-			return err
+		mergedRoleDefinitionsJSON, err := marshalJSON(detachedRoleDefinitions(config.RoleConfig))
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(snapshot.roleDefinitionsJSON, mergedRoleDefinitionsJSON) {
+			defs, defsJSON, err := c.normalizeRoleDefinitions(detachedRoleDefinitions(config.RoleConfig))
+			if err != nil {
+				logrus.WithError(err).Errorln("Failed to normalize merged role configuration")
+				return nil, err
+			}
+			normalized.roleDefinitionsJSON = defsJSON
+			normalized.roleDefinitionsChanged = !bytes.Equal(snapshot.roleDefinitionsJSON, defsJSON)
+			if normalized.roleDefinitionsChanged {
+				normalized.roleDefinitions = defs
+			}
 		}
 	}
 
 	if config.WorkflowConfig != nil {
-		if err := c.storeWorkflowDefinitions(config.WorkflowConfig.Definitions); err != nil {
-			logrus.WithError(err).Errorln("Failed to apply merged workflow configuration")
-			return err
+		mergedWorkflowDefinitionsJSON, err := marshalJSON(detachedWorkflowDefinitions(config.WorkflowConfig))
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(snapshot.workflowDefinitionsJSON, mergedWorkflowDefinitionsJSON) {
+			defs, defsJSON, err := c.normalizeWorkflowDefinitions(detachedWorkflowDefinitions(config.WorkflowConfig))
+			if err != nil {
+				logrus.WithError(err).Errorln("Failed to normalize merged workflow configuration")
+				return nil, err
+			}
+			normalized.workflowDefinitionsJSON = defsJSON
+			normalized.workflowDefinitionsChanged = !bytes.Equal(snapshot.workflowDefinitionsJSON, defsJSON)
+			if normalized.workflowDefinitionsChanged {
+				normalized.workflowDefinitions = defs
+			}
 		}
 	}
 
 	if config.ProviderConfig != nil {
-		if err := c.storeProviderDefinitions(config.ProviderConfig.Definitions); err != nil {
-			logrus.WithError(err).Errorln("Failed to apply merged provider configuration")
-			return err
+		mergedProviderDefinitionsJSON, err := marshalJSON(detachedProviderDefinitions(config.ProviderConfig))
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(snapshot.providerDefinitionsJSON, mergedProviderDefinitionsJSON) {
+			defs, defsJSON, err := c.normalizeProviderDefinitions(detachedProviderDefinitions(config.ProviderConfig))
+			if err != nil {
+				logrus.WithError(err).Errorln("Failed to normalize merged provider configuration")
+				return nil, err
+			}
+			normalized.providerDefinitionsJSON = defsJSON
+			normalized.providerDefinitionsChanged = !bytes.Equal(snapshot.providerDefinitionsJSON, defsJSON)
+			if normalized.providerDefinitionsChanged {
+				normalized.providerDefinitions = defs
+			}
 		}
 	}
 
-	return nil
+	return normalized, nil
+}
+
+func (c *Config) commitMergedDefinitions(diff *normalizedDefinitionsPatch, expectedGeneration uint64) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.configGeneration != expectedGeneration {
+		return false
+	}
+
+	changed := false
+	if diff.roleDefinitionsChanged {
+		c.Roles.Definitions = diff.roleDefinitions
+		changed = true
+	}
+	if diff.workflowDefinitionsChanged {
+		c.Workflows.Definitions = diff.workflowDefinitions
+		changed = true
+	}
+	if diff.providerDefinitionsChanged {
+		c.Providers.Definitions = diff.providerDefinitions
+		changed = true
+	}
+	if changed {
+		c.configGeneration++
+	}
+
+	return true
+}
+
+func marshalJSON(value any) ([]byte, error) {
+	return json.Marshal(value)
 }
 
 func mergeConfigSection(current any, incoming any, out any) error {
@@ -269,46 +462,148 @@ func (c *Config) updateProviders(providerConfig *ProviderDefinitionsConfig) erro
 }
 
 func (c *Config) storeRoleDefinitions(definitions map[string]models.Role) error {
-	defs, err := c.ApplyRoles([]*models.RoleDefinitions{{
-		Roles: definitions,
-	}})
+	defs, defsJSON, err := c.normalizeRoleDefinitions(definitions)
 	if err != nil {
 		return err
 	}
 
-	c.mu.Lock()
-	c.Roles.Definitions = defs
-	c.mu.Unlock()
-
-	return nil
+	return c.commitRoleDefinitions(defs, defsJSON)
 }
 
 func (c *Config) storeWorkflowDefinitions(definitions map[string]models.Workflow) error {
-	defs, err := c.ApplyWorkflows([]*models.WorkflowDefinitions{{
-		Workflows: definitions,
-	}})
+	defs, defsJSON, err := c.normalizeWorkflowDefinitions(definitions)
 	if err != nil {
 		return err
 	}
 
-	c.mu.Lock()
-	c.Workflows.Definitions = defs
-	c.mu.Unlock()
-
-	return nil
+	return c.commitWorkflowDefinitions(defs, defsJSON)
 }
 
 func (c *Config) storeProviderDefinitions(definitions map[string]models.ProviderConfig) error {
-	defs, err := c.ApplyProviders([]*models.ProviderDefinitions{{
-		Providers: definitions,
-	}})
+	defs, defsJSON, err := c.normalizeProviderDefinitions(definitions)
 	if err != nil {
 		return err
 	}
 
-	c.mu.Lock()
-	c.Providers.Definitions = defs
-	c.mu.Unlock()
+	return c.commitProviderDefinitions(defs, defsJSON)
+}
 
+func (c *Config) normalizeRoleDefinitions(definitions map[string]models.Role) (map[string]models.Role, []byte, error) {
+	defs, err := (&Config{}).ApplyRoles([]*models.RoleDefinitions{{
+		Roles: definitions,
+	}})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defsJSON, err := marshalJSON(defs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return defs, defsJSON, nil
+}
+
+func (c *Config) normalizeWorkflowDefinitions(definitions map[string]models.Workflow) (map[string]models.Workflow, []byte, error) {
+	defs, err := (&Config{mode: c.mode}).ApplyWorkflows([]*models.WorkflowDefinitions{{
+		Workflows: definitions,
+	}})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defsJSON, err := marshalJSON(defs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return defs, defsJSON, nil
+}
+
+func (c *Config) normalizeProviderDefinitions(definitions map[string]models.ProviderConfig) (map[string]models.ProviderConfig, []byte, error) {
+	defs, err := (&Config{}).ApplyProviders([]*models.ProviderDefinitions{{
+		Providers: definitions,
+	}})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defsJSON, err := marshalJSON(defs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return defs, defsJSON, nil
+}
+
+func (c *Config) commitRoleDefinitions(defs map[string]models.Role, defsJSON []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	currentJSON, err := marshalJSON(c.Roles.Definitions)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(currentJSON, defsJSON) {
+		return nil
+	}
+
+	c.Roles.Definitions = defs
+	c.configGeneration++
 	return nil
+}
+
+func (c *Config) commitWorkflowDefinitions(defs map[string]models.Workflow, defsJSON []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	currentJSON, err := marshalJSON(c.Workflows.Definitions)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(currentJSON, defsJSON) {
+		return nil
+	}
+
+	c.Workflows.Definitions = defs
+	c.configGeneration++
+	return nil
+}
+
+func (c *Config) commitProviderDefinitions(defs map[string]models.ProviderConfig, defsJSON []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	currentJSON, err := marshalJSON(c.Providers.Definitions)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(currentJSON, defsJSON) {
+		return nil
+	}
+
+	c.Providers.Definitions = defs
+	c.configGeneration++
+	return nil
+}
+
+func detachedRoleDefinitions(config *RoleConfig) map[string]models.Role {
+	if config == nil {
+		return nil
+	}
+	return config.Definitions
+}
+
+func detachedWorkflowDefinitions(config *WorkflowConfig) map[string]models.Workflow {
+	if config == nil {
+		return nil
+	}
+	return config.Definitions
+}
+
+func detachedProviderDefinitions(config *ProviderDefinitionsConfig) map[string]models.ProviderConfig {
+	if config == nil {
+		return nil
+	}
+	return config.Definitions
 }

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -58,26 +58,21 @@ func (c *Config) MergeConfiguration(config *RegistrationResponse) error {
 		return err
 	}
 
-	// Create a patch to see the differences between existing and new
-	incomingPatch, err := jsonpatch.CreateMergePatch(existingData, newData)
+	// Convert the merged configuration back to a struct so the in-memory
+	// config reflects the fully merged remote+local state rather than a
+	// sparse diff payload. Unmarshaling the sparse merge patch here would
+	// collapse omitted fields to zero values in typed structs.
+	var mergedConfig ConfigPatchRequest
+	err = json.Unmarshal(newData, &mergedConfig)
 
 	if err != nil {
-		logrus.WithError(err).Errorln("Failed to create merge patch for configuration diffing")
+		logrus.WithError(err).Errorln("Failed to unmarshal merged configuration")
 		return err
 	}
 
-	// Convert patches back to structs - these are the NEW changes from the remote
-	// server that we need to apply to our existing configuration
-	var incomingDiff ConfigPatchRequest
-	err = json.Unmarshal(incomingPatch, &incomingDiff)
-
-	if err != nil {
-		logrus.WithError(err).Errorln("Failed to unmarshal incoming patch")
-		return err
-	}
-
-	// Add these new changes to our existing configuration
-	err = c.applyPatch(incomingDiff)
+	// Apply the desired end state directly. applyPatch remains the helper for
+	// callers that actually have partial section diffs to merge locally first.
+	err = c.applyMergedConfig(mergedConfig)
 
 	if err != nil {
 		logrus.WithError(err).Errorln("Failed to apply incoming configuration patch")
@@ -139,6 +134,8 @@ func (c *Config) MergeConfiguration(config *RegistrationResponse) error {
 }
 
 func (c *Config) applyPatch(diff ConfigPatchRequest) error {
+	// applyPatch is the partial-patch helper: merge the incoming section diff
+	// with the current live section, then normalize and persist the result.
 	// Apply role changes
 	if diff.RoleConfig != nil {
 		err := c.updateRoles(diff.RoleConfig)
@@ -169,23 +166,149 @@ func (c *Config) applyPatch(diff ConfigPatchRequest) error {
 	return nil
 }
 
+// applyMergedConfig applies a fully merged server state. It normalizes each
+// definitions map and stores it directly without re-merging the same sections.
+func (c *Config) applyMergedConfig(config ConfigPatchRequest) error {
+	if config.RoleConfig != nil {
+		if err := c.storeRoleDefinitions(config.RoleConfig.Definitions); err != nil {
+			logrus.WithError(err).Errorln("Failed to apply merged role configuration")
+			return err
+		}
+	}
+
+	if config.WorkflowConfig != nil {
+		if err := c.storeWorkflowDefinitions(config.WorkflowConfig.Definitions); err != nil {
+			logrus.WithError(err).Errorln("Failed to apply merged workflow configuration")
+			return err
+		}
+	}
+
+	if config.ProviderConfig != nil {
+		if err := c.storeProviderDefinitions(config.ProviderConfig.Definitions); err != nil {
+			logrus.WithError(err).Errorln("Failed to apply merged provider configuration")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mergeConfigSection(current any, incoming any, out any) error {
+	currentData, err := json.Marshal(current)
+	if err != nil {
+		return err
+	}
+
+	incomingData, err := json.Marshal(incoming)
+	if err != nil {
+		return err
+	}
+
+	mergedData, err := jsonpatch.MergePatch(currentData, incomingData)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(mergedData, out)
+}
+
 func (c *Config) updateRoles(roleConfig *RoleConfig) error {
-	_, err := c.ApplyRoles([]*models.RoleDefinitions{{
-		Roles: roleConfig.Definitions,
-	}})
-	return err
+	c.mu.RLock()
+	current := RoleConfig{
+		Path:        c.Roles.Path,
+		URL:         c.Roles.URL,
+		Vault:       c.Roles.Vault,
+		Definitions: c.Roles.Definitions,
+	}
+	c.mu.RUnlock()
+
+	var merged RoleConfig
+	if err := mergeConfigSection(current, *roleConfig, &merged); err != nil {
+		return err
+	}
+
+	return c.storeRoleDefinitions(merged.Definitions)
 }
 
 func (c *Config) updateWorkflows(workflowConfig *WorkflowConfig) error {
-	_, err := c.ApplyWorkflows([]*models.WorkflowDefinitions{{
-		Workflows: workflowConfig.Definitions,
-	}})
-	return err
+	c.mu.RLock()
+	current := WorkflowConfig{
+		Path:        c.Workflows.Path,
+		URL:         c.Workflows.URL,
+		Vault:       c.Workflows.Vault,
+		Plugins:     c.Workflows.Plugins,
+		Definitions: c.Workflows.Definitions,
+	}
+	c.mu.RUnlock()
+
+	var merged WorkflowConfig
+	if err := mergeConfigSection(current, *workflowConfig, &merged); err != nil {
+		return err
+	}
+
+	return c.storeWorkflowDefinitions(merged.Definitions)
 }
 
 func (c *Config) updateProviders(providerConfig *ProviderDefinitionsConfig) error {
-	_, err := c.ApplyProviders([]*models.ProviderDefinitions{{
-		Providers: providerConfig.Definitions,
+	c.mu.RLock()
+	current := ProviderDefinitionsConfig{
+		Path:        c.Providers.Path,
+		URL:         c.Providers.URL,
+		Vault:       c.Providers.Vault,
+		Plugins:     c.Providers.Plugins,
+		Definitions: c.Providers.Definitions,
+	}
+	c.mu.RUnlock()
+
+	var merged ProviderDefinitionsConfig
+	if err := mergeConfigSection(current, *providerConfig, &merged); err != nil {
+		return err
+	}
+
+	return c.storeProviderDefinitions(merged.Definitions)
+}
+
+func (c *Config) storeRoleDefinitions(definitions map[string]models.Role) error {
+	defs, err := c.ApplyRoles([]*models.RoleDefinitions{{
+		Roles: definitions,
 	}})
-	return err
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.Roles.Definitions = defs
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Config) storeWorkflowDefinitions(definitions map[string]models.Workflow) error {
+	defs, err := c.ApplyWorkflows([]*models.WorkflowDefinitions{{
+		Workflows: definitions,
+	}})
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.Workflows.Definitions = defs
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Config) storeProviderDefinitions(definitions map[string]models.ProviderConfig) error {
+	defs, err := c.ApplyProviders([]*models.ProviderDefinitions{{
+		Providers: definitions,
+	}})
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.Providers.Definitions = defs
+	c.mu.Unlock()
+
+	return nil
 }

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/hashicorp/go-version"
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,6 +129,16 @@ func makeTestWorkflow(name, description string) models.Workflow {
 	}
 }
 
+func makeNormalizedRole(name, description string) models.Role {
+	return models.Role{
+		Version:     version.Must(version.NewVersion("1.0")),
+		Identifier:  name,
+		Name:        name,
+		Description: description,
+		Enabled:     true,
+	}
+}
+
 func makeTestProvider(name, description string) models.ProviderConfig {
 	return models.ProviderConfig{
 		Name:        name,
@@ -135,6 +146,16 @@ func makeTestProvider(name, description string) models.ProviderConfig {
 		Provider:    "mock",
 		Enabled:     true,
 	}
+}
+
+func makeTestProviderWithConfig(name, description string, config map[string]any) models.ProviderConfig {
+	provider := makeTestProvider(name, description)
+	basicConfig := models.BasicConfig{}
+	for key, value := range config {
+		basicConfig[key] = value
+	}
+	provider.Config = &basicConfig
+	return provider
 }
 
 // waitForPatch waits for a single PATCH call on the channel, or times out.
@@ -330,7 +351,7 @@ func TestMergeConfiguration_IdenticalConfigs(t *testing.T) {
 	server, patchCh := newSyncTestServer(t)
 
 	roles := map[string]models.Role{
-		"viewer": {Name: "viewer", Description: "Read-only", Enabled: true},
+		"viewer": makeNormalizedRole("viewer", "Read-only"),
 	}
 
 	config := newSyncTestConfig(t, roles, nil, nil, server.URL)
@@ -340,8 +361,37 @@ func TestMergeConfiguration_IdenticalConfigs(t *testing.T) {
 
 	err := config.MergeConfiguration(reg)
 	require.NoError(t, err)
+	assert.Equal(t, uint64(0), config.configGeneration, "identical sync should not advance the generation")
 
 	// The outgoing goroutine still fires (with an empty or no-op patch)
+	_, ok := waitForPatch(patchCh, 5*time.Second)
+	require.True(t, ok, "expected outgoing PATCH call")
+}
+
+func TestMergeConfiguration_MetadataOnlyRoleChangesAreIgnored(t *testing.T) {
+	server, patchCh := newSyncTestServer(t)
+
+	config := newSyncTestConfig(t,
+		map[string]models.Role{
+			"existing": makeNormalizedRole("existing", "same"),
+		},
+		nil, nil, server.URL,
+	)
+	config.Roles.Path = "./local-roles"
+
+	reg := makeRegistrationResponse(
+		map[string]models.Role{
+			"existing": makeNormalizedRole("existing", "same"),
+		},
+		nil, nil,
+	)
+	reg.Roles.Path = "./remote-roles"
+
+	err := config.MergeConfiguration(reg)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), config.configGeneration, "metadata-only sync changes should not advance generation")
+	assert.Equal(t, "./local-roles", config.Roles.Path, "definitions-only sync should not rewrite role metadata")
+
 	_, ok := waitForPatch(patchCh, 5*time.Second)
 	require.True(t, ok, "expected outgoing PATCH call")
 }
@@ -616,6 +666,28 @@ func TestApplyPatch_AppliesRoles(t *testing.T) {
 	err := config.applyPatch(diff)
 	assert.NoError(t, err)
 	assert.Contains(t, config.Roles.Definitions, "new-role")
+	assert.Equal(t, uint64(1), config.configGeneration)
+}
+
+func TestApplyPatch_IdenticalRolesDoNotAdvanceGeneration(t *testing.T) {
+	config := newSyncTestConfig(t,
+		map[string]models.Role{
+			"existing": makeNormalizedRole("existing", "same"),
+		},
+		nil, nil, "",
+	)
+
+	diff := ConfigPatchRequest{
+		RoleConfig: &RoleConfig{
+			Definitions: map[string]models.Role{
+				"existing": makeNormalizedRole("existing", "same"),
+			},
+		},
+	}
+
+	err := config.applyPatch(diff)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), config.configGeneration, "no-op apply should not advance generation")
 }
 
 func TestApplyPatch_SkipsNilWorkflows(t *testing.T) {
@@ -637,6 +709,208 @@ func TestApplyPatch_SkipsNilWorkflows(t *testing.T) {
 
 	err := config.applyPatch(diff)
 	assert.NoError(t, err)
+}
+
+func TestApplyMergedConfigWithSnapshot_RejectsStaleGeneration(t *testing.T) {
+	config := newSyncTestConfig(t,
+		map[string]models.Role{
+			"existing": makeNormalizedRole("existing", "before"),
+		},
+		nil, nil, "",
+	)
+
+	snapshot, err := config.snapshotConfigPatch()
+	require.NoError(t, err)
+
+	config.mu.Lock()
+	config.configGeneration++
+	config.mu.Unlock()
+
+	applied, err := config.applyMergedConfigWithSnapshot(snapshot, ConfigPatchRequest{
+		RoleConfig: &RoleConfig{
+			Definitions: map[string]models.Role{
+				"existing": makeNormalizedRole("existing", "after"),
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, applied, "expected generation mismatch to reject the stale merged apply")
+	assert.Equal(t, "before", config.Roles.Definitions["existing"].Description)
+}
+
+func TestApplyMergedConfigWithRetries_RetriesAndSucceeds(t *testing.T) {
+	config := newSyncTestConfig(t,
+		map[string]models.Role{
+			"existing": makeNormalizedRole("existing", "before"),
+		},
+		nil, nil, "",
+	)
+
+	attempts := 0
+	outgoingPatch, err := config.applyMergedConfigWithRetries(func(snapshot *configPatchSnapshot) (*buildMergedConfigResult, error) {
+		attempts++
+
+		if attempts == 1 {
+			config.mu.Lock()
+			config.configGeneration++
+			config.mu.Unlock()
+		}
+
+		return &buildMergedConfigResult{
+			config: ConfigPatchRequest{
+				RoleConfig: &RoleConfig{
+					Definitions: map[string]models.Role{
+						"existing": makeNormalizedRole("existing", "after"),
+					},
+				},
+			},
+			outgoingPatch: []byte(`{"roles":{}}`),
+		}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts, "expected one retry before success")
+	assert.JSONEq(t, `{"roles":{}}`, string(outgoingPatch))
+	assert.Equal(t, "after", config.Roles.Definitions["existing"].Description)
+	assert.Equal(t, uint64(2), config.configGeneration)
+}
+
+func TestSnapshotConfigPatch_DetachesRoleSlices(t *testing.T) {
+	config := newSyncTestConfig(t,
+		map[string]models.Role{
+			"editor": {
+				Name:      "editor",
+				Providers: []string{"aws-prod"},
+				Permissions: models.RolePermissions{
+					Allow: models.RoleStatements{{
+						Operations: []string{"s3:GetObject"},
+					}},
+				},
+				Enabled: true,
+			},
+		},
+		nil, nil, "",
+	)
+
+	snapshot, err := config.snapshotConfigPatch()
+	require.NoError(t, err)
+
+	role := config.Roles.Definitions["editor"]
+	role.Providers[0] = "gcp-prod"
+	role.Permissions.Allow[0].Operations[0] = "storage.objects.get"
+
+	snapRole, exists := snapshot.request.RoleConfig.Definitions["editor"]
+	require.True(t, exists)
+	assert.Equal(t, "aws-prod", snapRole.Providers[0])
+	assert.Equal(t, "s3:GetObject", snapRole.Permissions.Allow[0].Operations[0])
+}
+
+func TestSnapshotConfigPatch_DetachesWorkflowDefinitions(t *testing.T) {
+	config := newSyncTestConfig(t,
+		nil,
+		map[string]models.Workflow{
+			"approval": makeTestWorkflow("approval", "original"),
+		},
+		nil, "",
+	)
+
+	snapshot, err := config.snapshotConfigPatch()
+	require.NoError(t, err)
+
+	workflow := config.Workflows.Definitions["approval"]
+	workflow.Workflow.Do = nil
+
+	snapWorkflow, exists := snapshot.request.WorkflowConfig.Definitions["approval"]
+	require.True(t, exists)
+	require.NotNil(t, snapWorkflow.Workflow)
+	assert.NotNil(t, snapWorkflow.Workflow.Do)
+}
+
+func TestSnapshotConfigPatch_DetachesProviderConfig(t *testing.T) {
+	config := &Config{
+		Providers: ProviderDefinitionsConfig{
+			Definitions: map[string]models.ProviderConfig{
+				"mock-primary": makeTestProviderWithConfig("mock-primary", "primary", map[string]any{
+					"region": "us-east-1",
+				}),
+			},
+		},
+	}
+
+	snapshot, err := config.snapshotConfigPatch()
+	require.NoError(t, err)
+
+	provider := config.Providers.Definitions["mock-primary"]
+	require.NotNil(t, provider.Config)
+	provider.Config.SetKeyWithValue("region", "eu-west-1")
+
+	snapProvider, exists := snapshot.request.ProviderConfig.Definitions["mock-primary"]
+	require.True(t, exists)
+	require.NotNil(t, snapProvider.Config)
+	region, ok := snapProvider.Config.GetString("region")
+	require.True(t, ok)
+	assert.Equal(t, "us-east-1", region)
+}
+
+func TestKnownGap_NestedProviderMutationsShouldAdvanceConfigGeneration(t *testing.T) {
+	t.Skip("expected failure until #306: nested provider config mutations bypass configGeneration")
+
+	config := &Config{
+		Providers: ProviderDefinitionsConfig{
+			Definitions: map[string]models.ProviderConfig{
+				"mock-primary": makeTestProviderWithConfig("mock-primary", "primary", map[string]any{
+					"region": "us-east-1",
+				}),
+			},
+		},
+	}
+
+	provider := config.Providers.Definitions["mock-primary"]
+	require.NotNil(t, provider.Config)
+	provider.Config.SetKeyWithValue("region", "eu-west-1")
+
+	assert.Equal(t, uint64(1), config.configGeneration, "nested provider mutations should participate in generation tracking")
+}
+
+func TestKnownGap_NestedRoleMutationsShouldAdvanceConfigGeneration(t *testing.T) {
+	t.Skip("expected failure until #306: nested role mutations bypass configGeneration")
+
+	config := newSyncTestConfig(t,
+		map[string]models.Role{
+			"editor": {
+				Name:      "editor",
+				Providers: []string{"aws-prod"},
+				Permissions: models.RolePermissions{
+					Allow: models.RoleStatements{{
+						Operations: []string{"s3:GetObject"},
+					}},
+				},
+				Enabled: true,
+			},
+		},
+		nil, nil, "",
+	)
+
+	role := config.Roles.Definitions["editor"]
+	role.Permissions.Allow[0].Operations[0] = "storage.objects.get"
+
+	assert.Equal(t, uint64(1), config.configGeneration, "nested role mutations should participate in generation tracking")
+}
+
+func TestKnownGap_NestedWorkflowMutationsShouldAdvanceConfigGeneration(t *testing.T) {
+	t.Skip("expected failure until #306: nested workflow mutations bypass configGeneration")
+
+	config := newSyncTestConfig(t,
+		nil,
+		map[string]models.Workflow{
+			"approval": makeTestWorkflow("approval", "original"),
+		},
+		nil, "",
+	)
+
+	workflow := config.Workflows.Definitions["approval"]
+	workflow.Workflow.Do = nil
+
+	assert.Equal(t, uint64(1), config.configGeneration, "nested workflow mutations should participate in generation tracking")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thand-io/agent/internal/models"
@@ -116,6 +117,26 @@ func makeRegistrationResponse(
 	return resp
 }
 
+func makeTestWorkflow(name, description string) models.Workflow {
+	return models.Workflow{
+		Name:        name,
+		Description: description,
+		Enabled:     true,
+		Workflow: &model.Workflow{
+			Do: &model.TaskList{},
+		},
+	}
+}
+
+func makeTestProvider(name, description string) models.ProviderConfig {
+	return models.ProviderConfig{
+		Name:        name,
+		Description: description,
+		Provider:    "mock",
+		Enabled:     true,
+	}
+}
+
 // waitForPatch waits for a single PATCH call on the channel, or times out.
 func waitForPatch(ch <-chan syncPatchCall, timeout time.Duration) (syncPatchCall, bool) {
 	select {
@@ -147,6 +168,11 @@ func TestMergeConfiguration_ServerSendsNewRoles(t *testing.T) {
 	err := config.MergeConfiguration(reg)
 	require.NoError(t, err)
 
+	role, exists := config.Roles.Definitions["admin"]
+	require.True(t, exists, "expected synced role to be stored locally")
+	assert.Equal(t, "admin", role.Name)
+	assert.True(t, role.Enabled)
+
 	_, ok := waitForPatch(patchCh, 5*time.Second)
 	require.True(t, ok, "expected outgoing PATCH call")
 }
@@ -157,7 +183,8 @@ func TestMergeConfiguration_ServerSendsUpdatedRole(t *testing.T) {
 	// Local config has an existing role
 	config := newSyncTestConfig(t,
 		map[string]models.Role{
-			"editor": {Name: "editor", Description: "Can edit", Enabled: true},
+			"editor":    {Name: "editor", Description: "Can edit", Enabled: true},
+			"untouched": {Name: "untouched", Description: "Keep me", Enabled: true},
 		},
 		nil, nil, server.URL,
 	)
@@ -172,6 +199,128 @@ func TestMergeConfiguration_ServerSendsUpdatedRole(t *testing.T) {
 
 	err := config.MergeConfiguration(reg)
 	require.NoError(t, err)
+
+	role, exists := config.Roles.Definitions["editor"]
+	require.True(t, exists, "expected synced role to be stored locally")
+	assert.Equal(t, "Can edit and publish", role.Description)
+	assert.True(t, role.Enabled)
+	assert.Contains(t, config.Roles.Definitions, "untouched")
+
+	_, ok := waitForPatch(patchCh, 5*time.Second)
+	require.True(t, ok, "expected outgoing PATCH call")
+}
+
+func TestMergeConfiguration_ServerSendsNewWorkflows(t *testing.T) {
+	server, patchCh := newSyncTestServer(t)
+
+	config := newSyncTestConfig(t, nil, nil, nil, server.URL)
+
+	reg := makeRegistrationResponse(
+		nil,
+		map[string]models.Workflow{
+			"approval": makeTestWorkflow("approval", "Handles approvals"),
+		},
+		nil,
+	)
+
+	err := config.MergeConfiguration(reg)
+	require.NoError(t, err)
+
+	workflow, exists := config.Workflows.Definitions["approval"]
+	require.True(t, exists, "expected synced workflow to be stored locally")
+	assert.Equal(t, "Handles approvals", workflow.Description)
+	require.NotNil(t, workflow.Workflow)
+
+	_, ok := waitForPatch(patchCh, 5*time.Second)
+	require.True(t, ok, "expected outgoing PATCH call")
+}
+
+func TestMergeConfiguration_ServerSendsUpdatedWorkflow(t *testing.T) {
+	server, patchCh := newSyncTestServer(t)
+
+	config := newSyncTestConfig(t,
+		nil,
+		map[string]models.Workflow{
+			"existing":  makeTestWorkflow("existing", "Existing workflow"),
+			"unchanged": makeTestWorkflow("unchanged", "Keep me"),
+		},
+		nil,
+		server.URL,
+	)
+
+	reg := makeRegistrationResponse(
+		nil,
+		map[string]models.Workflow{
+			"existing": makeTestWorkflow("existing", "Updated workflow"),
+		},
+		nil,
+	)
+
+	err := config.MergeConfiguration(reg)
+	require.NoError(t, err)
+
+	workflow, exists := config.Workflows.Definitions["existing"]
+	require.True(t, exists, "expected synced workflow to be stored locally")
+	assert.Equal(t, "Updated workflow", workflow.Description)
+	assert.Contains(t, config.Workflows.Definitions, "unchanged")
+
+	_, ok := waitForPatch(patchCh, 5*time.Second)
+	require.True(t, ok, "expected outgoing PATCH call")
+}
+
+func TestMergeConfiguration_ServerSendsNewProviders(t *testing.T) {
+	server, patchCh := newSyncTestServer(t)
+
+	config := newSyncTestConfig(t, nil, nil, nil, server.URL)
+
+	reg := makeRegistrationResponse(
+		nil,
+		nil,
+		map[string]models.ProviderConfig{
+			"mock-primary": makeTestProvider("mock-primary", "Primary mock provider"),
+		},
+	)
+
+	err := config.MergeConfiguration(reg)
+	require.NoError(t, err)
+
+	provider, exists := config.Providers.Definitions["mock-primary"]
+	require.True(t, exists, "expected synced provider to be stored locally")
+	assert.Equal(t, "Primary mock provider", provider.Description)
+	assert.Equal(t, "mock", provider.Provider)
+
+	_, ok := waitForPatch(patchCh, 5*time.Second)
+	require.True(t, ok, "expected outgoing PATCH call")
+}
+
+func TestMergeConfiguration_ServerSendsUpdatedProvider(t *testing.T) {
+	server, patchCh := newSyncTestServer(t)
+
+	config := newSyncTestConfig(t,
+		nil,
+		nil,
+		map[string]models.ProviderConfig{
+			"mock-primary": makeTestProvider("mock-primary", "Old provider description"),
+			"mock-extra":   makeTestProvider("mock-extra", "Keep me"),
+		},
+		server.URL,
+	)
+
+	reg := makeRegistrationResponse(
+		nil,
+		nil,
+		map[string]models.ProviderConfig{
+			"mock-primary": makeTestProvider("mock-primary", "Updated provider description"),
+		},
+	)
+
+	err := config.MergeConfiguration(reg)
+	require.NoError(t, err)
+
+	provider, exists := config.Providers.Definitions["mock-primary"]
+	require.True(t, exists, "expected synced provider to be stored locally")
+	assert.Equal(t, "Updated provider description", provider.Description)
+	assert.Contains(t, config.Providers.Definitions, "mock-extra")
 
 	_, ok := waitForPatch(patchCh, 5*time.Second)
 	require.True(t, ok, "expected outgoing PATCH call")
@@ -217,6 +366,11 @@ func TestMergeConfiguration_PartialConfig_OnlyRoles(t *testing.T) {
 
 	err := config.MergeConfiguration(reg)
 	require.NoError(t, err)
+
+	role, exists := config.Roles.Definitions["new-role"]
+	require.True(t, exists, "expected synced role to be stored locally")
+	assert.Equal(t, "new-role", role.Name)
+	assert.Contains(t, config.Roles.Definitions, "existing")
 
 	_, ok := waitForPatch(patchCh, 5*time.Second)
 	require.True(t, ok, "expected outgoing PATCH call")
@@ -461,6 +615,7 @@ func TestApplyPatch_AppliesRoles(t *testing.T) {
 
 	err := config.applyPatch(diff)
 	assert.NoError(t, err)
+	assert.Contains(t, config.Roles.Definitions, "new-role")
 }
 
 func TestApplyPatch_SkipsNilWorkflows(t *testing.T) {


### PR DESCRIPTION
This fixes a pre-existing config sync bug where server-synced role, workflow, and provider definitions could be validated without becoming the live in-memory config, and then hardens that merged sync path against stale-snapshot lost updates.

## How to Read

- Look at the test results (comments below)
- start with the first commit only; two concerns: (1) `Apply*` results get thrown away?, and (2) sparse diffs would cause zeroed values that the validation would throw away anyway.

If that makes sense:
- second commit highlights a potential concurrency issue (lost updates when switching from RLock to Lock sections).

## What changed
- apply the **full merged server state** directly in `MergeConfiguration`, instead of routing that merged state back through the partial-patch helper
- keep `applyPatch` as the helper for real partial section diffs, with shared normalize/store helpers underneath
- add generation-based retry around the merged sync path only, with definitions-only compare/commit and detached snapshots for retry isolation

## Residual gap
Definition maps are now treated as immutable snapshots for sync and reload purposes, but broader nested-mutation and lock-discipline cleanup is still tracked separately in #306. The skipped evidence tests in this branch document that remaining gap without widening this PR.

## Validation
- `go test ./internal/config`
- `go test ./...`
