### PR TITLE
fix: shard oversized provider cookies without dropping oauth tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __debug_bin*
 
 # Go workspace file
 go.work
+go.work.sum
 
 # Build output
 /bin/

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"github.com/sirupsen/logrus"
@@ -542,11 +541,6 @@ func (s *Server) getAuthCallbackPage(c *gin.Context, auth models.AuthWrapper) {
 //	@Router			/auth/logout [get]
 //	@Router			/auth/logout/{provider} [get]
 func (s *Server) getLogoutPage(c *gin.Context) {
-
-	cookie := sessions.DefaultMany(c, ThandCookieName)
-	cookie.Clear()
-
-	// Need to loop over all cookies and clear them
 	provider := c.Param("provider")
 
 	if len(provider) > 0 {
@@ -558,46 +552,19 @@ func (s *Server) getLogoutPage(c *gin.Context) {
 			return
 		}
 
-		providerCookie := sessions.DefaultMany(c, CreateCookieName(provider))
-		providerCookie.Clear()
-
-		err = providerCookie.Save()
-
-		if err != nil {
-			s.getErrorPage(c, http.StatusInternalServerError, "Failed to clear provider session", err)
-			return
-		}
+		s.clearProviderCookies(c, provider)
 
 	} else {
 
 		allProviders := s.Config.GetProvidersByCapability(models.ProviderCapabilityAuthorizer)
 
 		for providerName := range allProviders {
-
-			cookie := sessions.DefaultMany(c, CreateCookieName(providerName))
-
-			if cookie == nil {
-				continue
-			}
-
-			cookie.Clear()
-			err := cookie.Save()
-
-			if err != nil {
-				s.getErrorPage(c, http.StatusInternalServerError, "Failed to clear provider session", err)
-				return
-			}
-
+			s.clearProviderCookies(c, providerName)
 		}
 
 	}
 
-	err := cookie.Save()
-
-	if err != nil {
-		s.getErrorPage(c, http.StatusInternalServerError, "Failed to clear session", err)
-		return
-	}
+	s.clearDefaultProviderCookies(c)
 
 	if s.canAcceptHtml(c) {
 		c.Redirect(http.StatusTemporaryRedirect, "/")

--- a/internal/daemon/cookies.go
+++ b/internal/daemon/cookies.go
@@ -4,91 +4,467 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/securecookie"
+	gsessions "github.com/gorilla/sessions"
 	"github.com/sirupsen/logrus"
 	"github.com/thand-io/agent/internal/models"
 	"golang.org/x/net/publicsuffix"
 )
 
-var ThandCookieName = "_thand_v1"
-var ThandCookieAttributeSessionName = "session"
-var ThandCookieAttributeActiveName = "active"
+// Provider session cookies can exceed the practical per-cookie size limit once
+// the encoded LocalSession is wrapped by securecookie, especially for OAuth2
+// providers with large access or refresh tokens. The v2 cookie transport keeps
+// the small "active provider" cookie on gin sessions, but stores provider
+// session state in a dedicated cookie format that signs the full payload once
+// and then shards that signed value across multiple cookies when needed.
+//
+// Constraints and rollout rules:
+//   - Sharding is only a browser transport detail; the LocalSession wire format
+//     stays unchanged.
+//   - Each shard targets about 3500 bytes of cookie value to leave headroom for
+//     cookie metadata and intermediary limits.
+//   - A provider cookie may use at most 3 shards. Larger signed payloads are
+//     rejected instead of allowing unbounded header growth.
+//   - Sharding works around single-cookie limits, but not total request-header
+//     limits enforced by browsers, proxies, or ingress layers. The shard cap is
+//     the explicit budget for one provider session.
+//   - The shard cap is part of the v2 transport contract. Changing the writer
+//     to emit more shards without first upgrading all readers can cause older
+//     nodes to reject and clear newer cookies, so incompatible shard-budget
+//     changes should use a new cookie version.
+//   - During rollout we write only v2, read v2 first, and fall back to v1 only
+//     when v2 is absent. Partial or corrupt v2 state is treated as invalid and
+//     cleared rather than silently downgraded.
+const (
+	ThandLegacyCookieName           = "_thand_v1"
+	ThandCookieName                 = "_thand_v2"
+	ThandCookieAttributeSessionName = "session"
+	ThandCookieAttributeActiveName  = "active"
+	providerCookieChunkPrefix       = "chunks-"
+	providerCookieChunkSize         = 3500 // Leave headroom under practical per-cookie limits.
+	providerCookieMaxShards         = 3    // Bound aggregate header growth; changing this is a v2 wire-contract change.
+	providerCookieMaxValueSize      = providerCookieChunkSize * providerCookieMaxShards
+)
+
+type providerCookieVersion string
+
+const (
+	providerCookieVersionCurrent providerCookieVersion = "v2"
+	providerCookieVersionLegacy  providerCookieVersion = "v1"
+)
 
 func (s *Server) setAuthCookie(c *gin.Context, authProvider string, localSession *models.LocalSession) error {
-
-	// Copy the session and remove the endpoint data as we don't want to store that in the cookie
-	// This reduces the size of the cookie significantly
-	copiedLocalSession := localSession.CopyWithoutEndpoint()
-
-	// Strip the local session to clear endpoint data for cookie
-	getEncodedCookie := copiedLocalSession.GetEncodedLocalSessionBytes()
-
-	if len(getEncodedCookie) == 0 {
-		logrus.WithFields(logrus.Fields{
-			"provider": authProvider,
-		}).Errorln("Failed to encode local session for cookie")
-		return fmt.Errorf("failed to encode local session for cookie")
+	if err := s.writeProviderCookie(c, authProvider, localSession); err != nil {
+		return err
 	}
 
-	// Check cookie size limit (generally 4096 bytes)
-	// getEncodedCookie is raw bytes. Session store will base64 encode it (x1.33).
-	// 2800 * 1.33 = 3733 bytes. Plus overhead (HMAC etc), it should fit in 4096.
-	if len(getEncodedCookie) > 2800 {
-		logrus.WithFields(logrus.Fields{
-			"provider": authProvider,
-			"encoded":  len(getEncodedCookie),
-		}).Errorln("Encoded session size exceeds cookie limit")
-		return fmt.Errorf("encoded session size exceeds cookie limit")
-	}
-
-	providerCookie := sessions.DefaultMany(c, CreateCookieName(authProvider))
-	providerCookie.Set(ThandCookieAttributeSessionName, getEncodedCookie)
-	err := providerCookie.Save()
-
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"provider": authProvider,
-			"encoded":  len(getEncodedCookie),
-		}).WithError(err).Errorln("Failed to save auth cookie")
-		return fmt.Errorf("failed to save auth cookie: %v", err)
-	}
-
-	// Set the active provider in the main thand cookie
-	defaultCookie := sessions.DefaultMany(c, ThandCookieName)
-	defaultCookie.Set(ThandCookieAttributeActiveName, authProvider)
-	err = defaultCookie.Save()
-
-	return err
-
+	return s.setDefaultProviderCookie(c, authProvider)
 }
 
 func CreateCookieName(provider string) string {
+	return createCookieNameWithBase(ThandCookieName, provider)
+}
+
+func CreateLegacyCookieName(provider string) string {
+	return createCookieNameWithBase(ThandLegacyCookieName, provider)
+}
+
+func createCookieNameWithBase(baseName string, provider string) string {
 	// base64 encode the provider name to ensure it's safe for cookie names, omitting padding
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(provider))
 	// prepend the thand cookie name
-	return fmt.Sprintf("%s_%s", ThandCookieName, encoded)
+	return fmt.Sprintf("%s_%s", baseName, encoded)
 }
 
-// getSessionStore creates a session store with secure cookie settings
-func (s *Server) getSessionStore(secret string) sessions.Store {
-
+func (s *Server) getCookieOptions() *sessions.Options {
 	hostname := s.Config.GetLoginServerHostname()
 	domain := getCookieDomain(hostname)
 
-	store := cookie.NewStore([]byte(secret))
-	store.Options(sessions.Options{
+	return &sessions.Options{
 		Path:     "/",
 		Domain:   domain,
 		MaxAge:   86400 * 7, // 7 days
 		HttpOnly: true,
 		Secure:   true,                 // Set to true in production with HTTPS
 		SameSite: http.SameSiteLaxMode, // Needed for OAuth2 redirects
-	})
+	}
+}
+
+// getSessionStore creates a session store with secure cookie settings
+func (s *Server) getSessionStore(secret string) sessions.Store {
+	store := cookie.NewStore([]byte(secret))
+	store.Options(*s.getCookieOptions())
 	return store
+}
+
+func (s *Server) getLegacySessionStore(secret string) *gsessions.CookieStore {
+	store := gsessions.NewCookieStore([]byte(secret))
+	options := s.getCookieOptions()
+	store.Options = &gsessions.Options{
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	}
+	store.MaxAge(options.MaxAge)
+	return store
+}
+
+// getProviderCookieCodecs returns securecookie codecs for the v2 provider-cookie
+// transport. MaxLength is disabled here because size enforcement is handled by
+// the explicit shard budget in writeProviderCookie.
+func (s *Server) getProviderCookieCodecs(secret string) []securecookie.Codec {
+	codecs := securecookie.CodecsFromPairs([]byte(secret))
+	options := s.getCookieOptions()
+	for _, codec := range codecs {
+		if sc, ok := codec.(*securecookie.SecureCookie); ok {
+			sc.MaxLength(0)
+			sc.MaxAge(options.MaxAge)
+		}
+	}
+	return codecs
+}
+
+func getSessionValueAsString(cookie sessions.Session, key string) string {
+	if cookie == nil {
+		return ""
+	}
+
+	value := cookie.Get(key)
+	if value == nil {
+		return ""
+	}
+
+	if provider, ok := value.(string); ok {
+		return provider
+	}
+
+	return ""
+}
+
+// getDefaultProviderCookieValue returns the active provider name from the small
+// default-provider cookie. It prefers the current v2 cookie and falls back to
+// the legacy v1 cookie during rollout.
+func (s *Server) getDefaultProviderCookieValue(c *gin.Context) string {
+	if provider := getSessionValueAsString(sessions.DefaultMany(c, ThandCookieName), ThandCookieAttributeActiveName); len(provider) > 0 {
+		return provider
+	}
+
+	return getSessionValueAsString(sessions.DefaultMany(c, ThandLegacyCookieName), ThandCookieAttributeActiveName)
+}
+
+// setDefaultProviderCookie records the active provider name in the current v2
+// default-provider cookie and clears the legacy v1 default cookie so subsequent
+// reads converge on the new format.
+func (s *Server) setDefaultProviderCookie(c *gin.Context, provider string) error {
+	defaultCookie := sessions.DefaultMany(c, ThandCookieName)
+	if defaultCookie == nil {
+		return fmt.Errorf("default provider cookie session not initialized")
+	}
+
+	defaultCookie.Set(ThandCookieAttributeActiveName, provider)
+	if err := defaultCookie.Save(); err != nil {
+		return err
+	}
+
+	s.clearCookieByName(c, ThandLegacyCookieName)
+	return nil
+}
+
+func (s *Server) clearDefaultProviderCookies(c *gin.Context) {
+	s.clearCookieByName(c, ThandCookieName)
+	s.clearCookieByName(c, ThandLegacyCookieName)
+}
+
+// writeProviderCookie writes the provider-specific LocalSession using the v2
+// transport format. The LocalSession payload is signed once, then stored either
+// directly in the base cookie or split across numbered shard cookies when the
+// signed value exceeds providerCookieChunkSize.
+func (s *Server) writeProviderCookie(c *gin.Context, provider string, localSession *models.LocalSession) error {
+	if localSession == nil {
+		return fmt.Errorf("local session is nil")
+	}
+
+	// Copy the session and remove the endpoint data as we don't want to store that in the cookie.
+	// This keeps the browser transport smaller without changing the LocalSession wire format.
+	copiedLocalSession := localSession.CopyWithoutEndpoint()
+	encodedLocalSession := copiedLocalSession.GetEncodedLocalSession()
+
+	if len(encodedLocalSession) == 0 {
+		logrus.WithFields(logrus.Fields{
+			"provider": provider,
+		}).Errorln("Failed to encode local session for cookie")
+		return fmt.Errorf("failed to encode local session for cookie")
+	}
+
+	cookieName := CreateCookieName(provider)
+	signedValue, err := securecookie.EncodeMulti(
+		cookieName,
+		encodedLocalSession,
+		s.getProviderCookieCodecs(s.Config.GetSecret())...,
+	)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"provider": provider,
+		}).WithError(err).Errorln("Failed to sign provider session cookie")
+		return fmt.Errorf("failed to encode provider session cookie: %w", err)
+	}
+
+	chunkCount := (len(signedValue) + providerCookieChunkSize - 1) / providerCookieChunkSize
+	if chunkCount > providerCookieMaxShards {
+		logrus.WithFields(logrus.Fields{
+			"provider":   provider,
+			"cookieName": cookieName,
+			"encoded":    len(signedValue),
+			"shards":     chunkCount,
+		}).Errorln("Signed session size exceeds bounded cookie/header budget")
+		return fmt.Errorf("signed provider session exceeds bounded cookie/header budget")
+	}
+
+	s.clearCookieSetFromRequest(c, cookieName)
+
+	if chunkCount <= 1 {
+		s.setCookieValue(c, cookieName, signedValue)
+	} else {
+		s.setCookieValue(c, cookieName, fmt.Sprintf("%s%d", providerCookieChunkPrefix, chunkCount))
+
+		for shard := 0; shard < chunkCount; shard++ {
+			start := shard * providerCookieChunkSize
+			end := start + providerCookieChunkSize
+			if end > len(signedValue) {
+				end = len(signedValue)
+			}
+
+			s.setCookieValue(
+				c,
+				fmt.Sprintf("%sC%d", cookieName, shard+1),
+				signedValue[start:end],
+			)
+		}
+	}
+
+	s.clearCookieByName(c, CreateLegacyCookieName(provider))
+	return nil
+}
+
+// readProviderLocalSession loads a provider cookie during the v1->v2 rollout.
+// It returns the decoded LocalSession, the cookie version used to satisfy the
+// read, whether any cookie state was present for that provider, and an error if
+// the discovered cookie state was invalid. A corrupt or partial v2 cookie set is
+// treated as found=true with an error so callers can fail closed and avoid
+// silently falling back to legacy state.
+func (s *Server) readProviderLocalSession(
+	c *gin.Context,
+	provider string,
+) (*models.LocalSession, providerCookieVersion, bool, error) {
+	currentCookieName := CreateCookieName(provider)
+	signedValue, found, err := s.readCurrentProviderCookieValue(c.Request, currentCookieName)
+	if found {
+		if err != nil {
+			s.clearCookieSetFromRequest(c, currentCookieName)
+			return nil, providerCookieVersionCurrent, true, err
+		}
+
+		localSession, err := s.decodeCurrentProviderCookieValue(currentCookieName, signedValue)
+		if err != nil {
+			s.clearCookieSetFromRequest(c, currentCookieName)
+			return nil, providerCookieVersionCurrent, true, err
+		}
+
+		return localSession, providerCookieVersionCurrent, true, nil
+	}
+
+	legacySession, found, err := s.readLegacyProviderLocalSession(c.Request, provider)
+	if err != nil {
+		return nil, providerCookieVersionLegacy, true, err
+	}
+
+	return legacySession, providerCookieVersionLegacy, found, nil
+}
+
+// readCurrentProviderCookieValue returns the signed v2 provider cookie payload.
+// For unsharded cookies it returns the base cookie value directly. For sharded
+// cookies it reassembles the numbered shard cookies named <cookieName>C1..CN.
+// The bool result reports whether any v2 cookie state was present at all.
+func (s *Server) readCurrentProviderCookieValue(
+	r *http.Request,
+	cookieName string,
+) (string, bool, error) {
+	cookie, err := r.Cookie(cookieName)
+	if err != nil || cookie == nil || len(cookie.Value) == 0 {
+		return "", false, nil
+	}
+
+	if !strings.HasPrefix(cookie.Value, providerCookieChunkPrefix) {
+		if len(cookie.Value) > providerCookieChunkSize {
+			return "", true, fmt.Errorf("provider cookie base value exceeds shard limit")
+		}
+		return cookie.Value, true, nil
+	}
+
+	shardCount, err := strconv.Atoi(strings.TrimPrefix(cookie.Value, providerCookieChunkPrefix))
+	if err != nil {
+		if len(cookie.Value) > providerCookieChunkSize {
+			return "", true, fmt.Errorf("provider cookie base value exceeds shard limit")
+		}
+		return cookie.Value, true, nil
+	}
+	if shardCount <= 0 || shardCount > providerCookieMaxShards {
+		return "", true, fmt.Errorf("invalid provider cookie shard count")
+	}
+
+	var builder strings.Builder
+	for shard := 1; shard <= shardCount; shard++ {
+		chunkCookie, chunkErr := r.Cookie(fmt.Sprintf("%sC%d", cookieName, shard))
+		if chunkErr != nil || chunkCookie == nil || len(chunkCookie.Value) == 0 {
+			return "", true, fmt.Errorf("provider cookie shard %d missing", shard)
+		}
+		if len(chunkCookie.Value) > providerCookieChunkSize {
+			return "", true, fmt.Errorf("provider cookie shard %d exceeds shard limit", shard)
+		}
+
+		builder.WriteString(chunkCookie.Value)
+		if builder.Len() > providerCookieMaxValueSize {
+			return "", true, fmt.Errorf("provider cookie value exceeds bounded shard budget")
+		}
+	}
+
+	return builder.String(), true, nil
+}
+
+// decodeCurrentProviderCookieValue verifies and decodes a signed v2 provider
+// cookie value back into a LocalSession. The signedValue input must be the full
+// reassembled securecookie payload for cookieName.
+func (s *Server) decodeCurrentProviderCookieValue(cookieName string, signedValue string) (*models.LocalSession, error) {
+	var encodedLocalSession string
+	if err := securecookie.DecodeMulti(
+		cookieName,
+		signedValue,
+		&encodedLocalSession,
+		s.getProviderCookieCodecs(s.Config.GetSecret())...,
+	); err != nil {
+		return nil, fmt.Errorf("failed to decode signed provider cookie: %w", err)
+	}
+
+	localSession, err := models.DecodedLocalSession(encodedLocalSession)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode provider local session: %w", err)
+	}
+
+	return localSession, nil
+}
+
+// readLegacyProviderLocalSession loads the legacy v1 gorilla session cookie for
+// provider. It returns found=false when the legacy cookie is absent, and found=true
+// with an error when the cookie exists but cannot be decoded.
+func (s *Server) readLegacyProviderLocalSession(
+	r *http.Request,
+	provider string,
+) (*models.LocalSession, bool, error) {
+	cookieName := CreateLegacyCookieName(provider)
+	if _, err := r.Cookie(cookieName); err != nil {
+		return nil, false, nil
+	}
+
+	legacyStore := s.getLegacySessionStore(s.Config.GetSecret())
+	legacySession, err := legacyStore.Get(r, cookieName)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to decode legacy provider cookie: %w", err)
+	}
+
+	sessionData := legacySession.Values[ThandCookieAttributeSessionName]
+	if sessionData == nil {
+		return nil, true, fmt.Errorf("legacy provider cookie missing session data")
+	}
+
+	localSession, err := getLocalSessionFromCookieData(sessionData)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return localSession, true, nil
+}
+
+// getLocalSessionFromCookieData normalizes legacy session payloads that may be
+// stored as either a string or raw bytes before decoding them into LocalSession.
+func getLocalSessionFromCookieData(sessionData any) (*models.LocalSession, error) {
+	switch v := sessionData.(type) {
+	case string:
+		return models.DecodedLocalSession(v)
+	case []byte:
+		return models.DecodedLocalSessionBytes(v)
+	default:
+		return nil, fmt.Errorf("invalid session data type: %T", sessionData)
+	}
+}
+
+func (s *Server) clearProviderCookies(c *gin.Context, provider string) {
+	s.clearCookieSetFromRequest(c, CreateCookieName(provider))
+	s.clearCookieByName(c, CreateLegacyCookieName(provider))
+}
+
+// clearCookieSetFromRequest expires the named base cookie plus any shard cookies
+// observed on the incoming request. This lets rewrites shrink a sharded cookie
+// set without leaving stale shard cookies behind.
+func (s *Server) clearCookieSetFromRequest(c *gin.Context, baseCookieName string) {
+	names := map[string]struct{}{
+		baseCookieName: {},
+	}
+
+	for _, cookie := range c.Request.Cookies() {
+		if cookie == nil {
+			continue
+		}
+
+		if cookie.Name == baseCookieName || strings.HasPrefix(cookie.Name, baseCookieName+"C") {
+			names[cookie.Name] = struct{}{}
+		}
+	}
+
+	for name := range names {
+		s.clearCookieByName(c, name)
+	}
+}
+
+func (s *Server) setCookieValue(c *gin.Context, name string, value string) {
+	options := s.getCookieOptions()
+	cookie := &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Expires:  time.Now().Add(time.Duration(options.MaxAge) * time.Second),
+		HttpOnly: options.HttpOnly,
+		Secure:   options.Secure,
+		SameSite: options.SameSite,
+	}
+	http.SetCookie(c.Writer, cookie)
+}
+
+func (s *Server) clearCookieByName(c *gin.Context, name string) {
+	options := s.getCookieOptions()
+	cookie := &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   -1,
+		Expires:  time.Unix(1, 0),
+		HttpOnly: options.HttpOnly,
+		Secure:   options.Secure,
+		SameSite: options.SameSite,
+	}
+	http.SetCookie(c.Writer, cookie)
 }
 
 // getCookieDomain determines the appropriate cookie domain based on the hostname.

--- a/internal/daemon/middleware.go
+++ b/internal/daemon/middleware.go
@@ -1,13 +1,11 @@
 package daemon
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"slices"
 	"strings"
 
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/thand-io/agent/internal/common"
@@ -302,20 +300,22 @@ func (s *Server) processProviderCookies(
 	}
 
 	for providerName := range providersToCheck {
-
-		cookie := sessions.DefaultMany(c, CreateCookieName(providerName))
-
-		if cookie == nil {
+		localSession, cookieVersion, found, err := s.readProviderLocalSession(c, providerName)
+		if !found {
 			continue
 		}
 
-		providerSessionData := cookie.Get(ThandCookieAttributeSessionName)
-
-		if providerSessionData == nil {
+		if err != nil {
+			logrus.WithError(err).
+				WithFields(logrus.Fields{
+					"provider": providerName,
+					"version":  cookieVersion,
+				}).
+				Warnln("Failed to read provider cookie")
 			continue
 		}
 
-		decodedSession, err := getDecodedSession(encryptionServer, providerSessionData)
+		decodedSession, err := localSession.GetDecodedSession(encryptionServer)
 		if err != nil {
 			logrus.WithError(err).
 				WithField("provider", providerName).
@@ -455,34 +455,28 @@ func (s *Server) handleAgentMode(c *gin.Context) {
 	cookiesSet := false
 
 	for providerName, remoteSession := range agentSessions {
+		existingSession, cookieVersion, found, err := s.readProviderLocalSession(c, providerName)
+		if err != nil {
+			logrus.WithError(err).
+				WithFields(logrus.Fields{
+					"provider": providerName,
+					"version":  cookieVersion,
+				}).
+				Warnln("Failed to read existing provider cookie during agent sync")
+		}
 
-		cookie := sessions.DefaultMany(c, CreateCookieName(providerName))
-
-		if cookie == nil {
+		newSession := remoteSession.CopyWithoutEndpoint().GetEncodedLocalSession()
+		if found && err == nil &&
+			cookieVersion == providerCookieVersionCurrent &&
+			existingSession.GetEncodedLocalSession() == newSession {
+			// Session already stored in the current format, no need to redirect.
 			continue
 		}
 
-		// Check if the cookie already has the same session data to avoid redirect loops
-		existingSession := cookie.Get(ThandCookieAttributeSessionName)
-		newSession := remoteSession.GetEncodedLocalSessionBytes()
-
-		if existingBytes, ok := existingSession.([]byte); ok {
-			if bytes.Equal(existingBytes, newSession) {
-				// Session already set, no need to redirect
-				continue
-			}
-		}
-
-		// Also check valid string session for backward compatibility (though we interpret equality strictly now)
-		// If existingSession is a string, it means it's the old format. We want to update it to bytes.
-		// So we don't "continue" here.
-
-		cookie.Set(ThandCookieAttributeSessionName, newSession)
-
-		err = cookie.Save()
-
-		if err != nil {
-			logrus.WithError(err).Warnln("Failed to save session cookie")
+		if err := s.writeProviderCookie(c, providerName, &remoteSession); err != nil {
+			logrus.WithError(err).
+				WithField("provider", providerName).
+				Warnln("Failed to save session cookie")
 			c.Next()
 			return
 		}
@@ -502,19 +496,7 @@ func (s *Server) handleAgentMode(c *gin.Context) {
 }
 
 func getDecodedSession(encryptor models.EncryptionImpl, sessionData any) (*models.ExportableSession, error) {
-
-	var localSession *models.LocalSession
-	var err error
-
-	switch v := sessionData.(type) {
-	case string:
-		localSession, err = models.DecodedLocalSession(v)
-	case []byte:
-		localSession, err = models.DecodedLocalSessionBytes(v)
-	default:
-		return nil, fmt.Errorf("invalid session data type: %T", sessionData)
-	}
-
+	localSession, err := getLocalSessionFromCookieData(sessionData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode local session: %w", err)
 	}
@@ -631,16 +613,10 @@ func (s *Server) resolveSession(c *gin.Context, authProviders ...string) (string
 	}
 
 	// Otherwise return the primary session if it exists
-	primaryCookie := sessions.DefaultMany(c, ThandCookieName)
-
-	if primaryCookie != nil {
-
-		activeProvider, ok := primaryCookie.Get(ThandCookieAttributeActiveName).(string)
-
-		if ok && len(activeProvider) > 0 {
-			if session, exists := remoteSessions[activeProvider]; exists {
-				return activeProvider, session, nil
-			}
+	activeProvider := s.getDefaultProviderCookieValue(c)
+	if len(activeProvider) > 0 {
+		if session, exists := remoteSessions[activeProvider]; exists {
+			return activeProvider, session, nil
 		}
 	}
 

--- a/internal/daemon/provider_cookies_test.go
+++ b/internal/daemon/provider_cookies_test.go
@@ -1,0 +1,899 @@
+package daemon
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	ginsessions "github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/securecookie"
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thand-io/agent/internal/config"
+	"github.com/thand-io/agent/internal/models"
+	sessionManager "github.com/thand-io/agent/internal/sessions"
+)
+
+const (
+	testThandCookieV1 = ThandLegacyCookieName
+	testThandCookieV2 = ThandCookieName
+)
+
+func TestAuthCookieLargeProviderSessionRoundTripUsesV2Shards(t *testing.T) {
+	provider := "oauth2-large"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	localSession := newLocalSessionForSignedCookieRange(
+		t,
+		provider,
+		server.Config.GetSecret(),
+		providerCookieChunkSize+1,
+		providerCookieChunkSize*providerCookieMaxShards,
+	)
+
+	writeResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth-cookie",
+		"/auth-cookie",
+		[]string{provider},
+		nil,
+		func(c *gin.Context) {
+			if err := server.setAuthCookie(c, provider, localSession); err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
+				return
+			}
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, writeResp.Code, writeResp.Body.String())
+
+	responseCookies := mergeCookies(nil, writeResp.Result().Cookies())
+	assertCookiePresent(t, responseCookies, CreateCookieName(provider))
+	assertCookiePresent(t, responseCookies, CreateCookieName(provider)+"C1")
+
+	expectedSession, err := localSession.GetDecodedSession(newMockEncryptor())
+	require.NoError(t, err)
+
+	foundSessions := map[string]*models.Session{}
+	readResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth-cookie",
+		"/auth-cookie",
+		[]string{provider},
+		responseCookies,
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, readResp.Code)
+	require.Contains(t, foundSessions, provider)
+	assertSessionsEqual(t, expectedSession.Session, foundSessions[provider])
+}
+
+func TestAuthCookieCleansStaleV2ShardsWhenSessionShrinks(t *testing.T) {
+	provider := "oauth2-shrink"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+
+	largeSession := newLocalSessionForSignedCookieRange(
+		t,
+		provider,
+		server.Config.GetSecret(),
+		providerCookieChunkSize+1,
+		providerCookieChunkSize*providerCookieMaxShards,
+	)
+	smallSession := newTestLocalSession(provider, 32)
+
+	firstResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth-cookie",
+		"/auth-cookie",
+		[]string{provider},
+		nil,
+		func(c *gin.Context) {
+			if err := server.setAuthCookie(c, provider, largeSession); err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
+				return
+			}
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, firstResp.Code, firstResp.Body.String())
+
+	secondResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth-cookie",
+		"/auth-cookie",
+		[]string{provider},
+		mergeCookies(nil, firstResp.Result().Cookies()),
+		func(c *gin.Context) {
+			if err := server.setAuthCookie(c, provider, smallSession); err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
+				return
+			}
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, secondResp.Code, secondResp.Body.String())
+
+	responseCookies := cookiesByName(secondResp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, CreateCookieName(provider)+"C1")
+}
+
+func TestProviderCookieReassemblesV2ShardedSession(t *testing.T) {
+	provider := "oauth2-v2"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	localSession := newLocalSessionForSignedCookieRange(
+		t,
+		provider,
+		server.Config.GetSecret(),
+		providerCookieChunkSize+1,
+		providerCookieChunkSize*providerCookieMaxShards,
+	)
+
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+	signedValue := encodeProviderCookieValue(t, server.Config.GetSecret(), v2CookieName, localSession)
+	requestCookies := shardProviderCookieValue(t, v2CookieName, signedValue)
+
+	expectedSession, err := localSession.GetDecodedSession(newMockEncryptor())
+	require.NoError(t, err)
+
+	foundSessions := map[string]*models.Session{}
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/provider-cookie",
+		"/provider-cookie",
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	require.Contains(t, foundSessions, provider)
+	assertSessionsEqual(t, expectedSession.Session, foundSessions[provider])
+}
+
+func TestProviderCookieFallsBackToLegacyV1WhenV2Absent(t *testing.T) {
+	provider := "oauth2-v1-fallback"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	localSession := newTestLocalSession(provider, 64)
+
+	expectedSession, err := localSession.GetDecodedSession(newMockEncryptor())
+	require.NoError(t, err)
+
+	legacyCookie := &http.Cookie{
+		Name:  createVersionedCookieName(testThandCookieV1, provider),
+		Value: encodeLegacyProviderCookieValue(t, server.Config.GetSecret(), provider, localSession),
+	}
+
+	foundSessions := map[string]*models.Session{}
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/provider-cookie",
+		"/provider-cookie",
+		[]string{provider},
+		[]*http.Cookie{legacyCookie},
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	require.Contains(t, foundSessions, provider)
+	assertSessionsEqual(t, expectedSession.Session, foundSessions[provider])
+}
+
+func TestProviderCookieRejectsPartialV2AndDoesNotFallbackToV1(t *testing.T) {
+	provider := "oauth2-partial"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+
+	legacySession := newTestLocalSession(provider, 64)
+	legacyCookie := &http.Cookie{
+		Name:  createVersionedCookieName(testThandCookieV1, provider),
+		Value: encodeLegacyProviderCookieValue(t, server.Config.GetSecret(), provider, legacySession),
+	}
+
+	partialSession := newLocalSessionForSignedCookieRange(
+		t,
+		provider,
+		server.Config.GetSecret(),
+		providerCookieChunkSize+1,
+		providerCookieChunkSize*providerCookieMaxShards,
+	)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+	partialValue := encodeProviderCookieValue(t, server.Config.GetSecret(), v2CookieName, partialSession)
+	partialCookies := shardProviderCookieValue(t, v2CookieName, partialValue)
+	require.GreaterOrEqual(t, len(partialCookies), 2)
+
+	requestCookies := append([]*http.Cookie{
+		partialCookies[0],
+		partialCookies[1],
+		legacyCookie,
+	})
+
+	foundSessions := map[string]*models.Session{}
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/provider-cookie",
+		"/provider-cookie",
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	assert.NotContains(t, foundSessions, provider)
+
+	responseCookies := cookiesByName(resp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, v2CookieName)
+	assertExpiredCookie(t, responseCookies, v2CookieName+"C1")
+}
+
+func TestProviderCookieRejectsOversizedUnshardedV2BaseCookie(t *testing.T) {
+	provider := "oauth2-oversized-base"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	requestCookies := []*http.Cookie{
+		{
+			Name:  v2CookieName,
+			Value: repeatedToken("oversized-base", providerCookieChunkSize+1),
+		},
+	}
+
+	foundSessions := map[string]*models.Session{}
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/provider-cookie",
+		"/provider-cookie",
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	assert.NotContains(t, foundSessions, provider)
+
+	responseCookies := cookiesByName(resp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, v2CookieName)
+}
+
+func TestProviderCookieRejectsOversizedV2Shard(t *testing.T) {
+	provider := "oauth2-oversized-shard"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	requestCookies := []*http.Cookie{
+		{
+			Name:  v2CookieName,
+			Value: "chunks-1",
+		},
+		{
+			Name:  v2CookieName + "C1",
+			Value: repeatedToken("oversized-shard", providerCookieChunkSize+1),
+		},
+	}
+
+	foundSessions := map[string]*models.Session{}
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/provider-cookie",
+		"/provider-cookie",
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	assert.NotContains(t, foundSessions, provider)
+
+	responseCookies := cookiesByName(resp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, v2CookieName)
+	assertExpiredCookie(t, responseCookies, v2CookieName+"C1")
+}
+
+func TestProviderCookieRejectsReassembledPayloadOverBoundedBudget(t *testing.T) {
+	provider := "oauth2-oversized-total"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	requestCookies := []*http.Cookie{
+		{
+			Name:  v2CookieName,
+			Value: fmt.Sprintf("chunks-%d", providerCookieMaxShards),
+		},
+		{
+			Name:  v2CookieName + "C1",
+			Value: repeatedToken("oversized-total-1", providerCookieChunkSize),
+		},
+		{
+			Name:  v2CookieName + "C2",
+			Value: repeatedToken("oversized-total-2", providerCookieChunkSize),
+		},
+		{
+			Name:  v2CookieName + "C3",
+			Value: repeatedToken("oversized-total-3", providerCookieChunkSize+1),
+		},
+	}
+
+	foundSessions := map[string]*models.Session{}
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/provider-cookie",
+		"/provider-cookie",
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.processProviderCookies(c, newMockEncryptor(), foundSessions)
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	assert.NotContains(t, foundSessions, provider)
+
+	responseCookies := cookiesByName(resp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, v2CookieName)
+	assertExpiredCookie(t, responseCookies, v2CookieName+"C1")
+	assertExpiredCookie(t, responseCookies, v2CookieName+"C2")
+	assertExpiredCookie(t, responseCookies, v2CookieName+"C3")
+}
+
+func TestReadCurrentProviderCookieValueRejectsOversizedUnshardedBase(t *testing.T) {
+	provider := "oauth2-read-oversized-base"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider-cookie", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName,
+		Value: repeatedToken("oversized-base", providerCookieChunkSize+1),
+	})
+
+	value, found, err := server.readCurrentProviderCookieValue(req, v2CookieName)
+	require.True(t, found)
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "provider cookie base value exceeds shard limit")
+}
+
+func TestReadCurrentProviderCookieValueRejectsOversizedShard(t *testing.T) {
+	provider := "oauth2-read-oversized-shard"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider-cookie", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName,
+		Value: "chunks-1",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName + "C1",
+		Value: repeatedToken("oversized-shard", providerCookieChunkSize+1),
+	})
+
+	value, found, err := server.readCurrentProviderCookieValue(req, v2CookieName)
+	require.True(t, found)
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "provider cookie shard 1 exceeds shard limit")
+}
+
+func TestReadCurrentProviderCookieValueRejectsOversizedReassembledValue(t *testing.T) {
+	provider := "oauth2-read-oversized-total"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider-cookie", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName,
+		Value: fmt.Sprintf("chunks-%d", providerCookieMaxShards),
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName + "C1",
+		Value: repeatedToken("oversized-total-1", providerCookieChunkSize),
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName + "C2",
+		Value: repeatedToken("oversized-total-2", providerCookieChunkSize),
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName + "C3",
+		Value: repeatedToken("oversized-total-3", providerCookieChunkSize+1),
+	})
+
+	value, found, err := server.readCurrentProviderCookieValue(req, v2CookieName)
+	require.True(t, found)
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "provider cookie shard 3 exceeds shard limit")
+}
+
+func TestDeleteSessionClearsLegacyAndV2ProviderCookies(t *testing.T) {
+	provider := "oauth2-delete"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	localSession := newTestLocalSession(provider, 64)
+
+	requestCookies := []*http.Cookie{
+		{
+			Name:  createVersionedCookieName(testThandCookieV1, provider),
+			Value: encodeLegacyProviderCookieValue(t, server.Config.GetSecret(), provider, localSession),
+		},
+		{
+			Name:  createVersionedCookieName(testThandCookieV2, provider),
+			Value: encodeProviderCookieValue(t, server.Config.GetSecret(), createVersionedCookieName(testThandCookieV2, provider), localSession),
+		},
+		{
+			Name:  testThandCookieV1,
+			Value: encodeDefaultProviderCookieValue(t, server.Config.GetSecret(), testThandCookieV1, provider),
+		},
+		{
+			Name:  testThandCookieV2,
+			Value: encodeDefaultProviderCookieValue(t, server.Config.GetSecret(), testThandCookieV2, provider),
+		},
+	}
+
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodDelete,
+		"/session/:provider",
+		fmt.Sprintf("/session/%s", provider),
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.deleteSession(c)
+		},
+	)
+
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	responseCookies := cookiesByName(resp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, createVersionedCookieName(testThandCookieV1, provider))
+	assertExpiredCookie(t, responseCookies, createVersionedCookieName(testThandCookieV2, provider))
+	assertExpiredCookie(t, responseCookies, testThandCookieV1)
+	assertExpiredCookie(t, responseCookies, testThandCookieV2)
+}
+
+func TestGetLogoutPageClearsLegacyAndV2Cookies(t *testing.T) {
+	provider := "oauth2-logout"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	localSession := newTestLocalSession(provider, 64)
+
+	requestCookies := []*http.Cookie{
+		{
+			Name:  createVersionedCookieName(testThandCookieV1, provider),
+			Value: encodeLegacyProviderCookieValue(t, server.Config.GetSecret(), provider, localSession),
+		},
+		{
+			Name:  createVersionedCookieName(testThandCookieV2, provider),
+			Value: encodeProviderCookieValue(t, server.Config.GetSecret(), createVersionedCookieName(testThandCookieV2, provider), localSession),
+		},
+		{
+			Name:  testThandCookieV1,
+			Value: encodeDefaultProviderCookieValue(t, server.Config.GetSecret(), testThandCookieV1, provider),
+		},
+		{
+			Name:  testThandCookieV2,
+			Value: encodeDefaultProviderCookieValue(t, server.Config.GetSecret(), testThandCookieV2, provider),
+		},
+	}
+
+	resp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth/logout",
+		"/auth/logout",
+		[]string{provider},
+		requestCookies,
+		func(c *gin.Context) {
+			server.getLogoutPage(c)
+		},
+	)
+
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	responseCookies := cookiesByName(resp.Result().Cookies())
+	assertExpiredCookie(t, responseCookies, createVersionedCookieName(testThandCookieV1, provider))
+	assertExpiredCookie(t, responseCookies, createVersionedCookieName(testThandCookieV2, provider))
+	assertExpiredCookie(t, responseCookies, testThandCookieV1)
+	assertExpiredCookie(t, responseCookies, testThandCookieV2)
+}
+
+func TestHandleAgentModeMigratesLegacyV1CookieWithoutRedirectLoop(t *testing.T) {
+	provider := "oauth2-agent"
+	server := newTestCookieServer(t, config.ModeAgent)
+
+	restoreSessionManagerPath := sessionManager.SESSION_MANAGER_PATH
+	restoreServers := sessionManager.GetSessionManager().Servers
+	sessionManager.SESSION_MANAGER_PATH = t.TempDir()
+	sessionManager.GetSessionManager().Servers = make(map[string]sessionManager.LoginServer)
+	t.Cleanup(func() {
+		sessionManager.SESSION_MANAGER_PATH = restoreSessionManagerPath
+		sessionManager.GetSessionManager().Servers = restoreServers
+	})
+
+	localSession := newTestLocalSession(provider, 64)
+	err := sessionManager.GetSessionManager().AddSession(
+		server.Config.GetLoginServerHostname(),
+		provider,
+		*localSession,
+	)
+	require.NoError(t, err)
+
+	legacyCookie := &http.Cookie{
+		Name:  createVersionedCookieName(testThandCookieV1, provider),
+		Value: encodeLegacyProviderCookieValue(t, server.Config.GetSecret(), provider, localSession),
+	}
+
+	firstResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/agent-mode",
+		"/agent-mode",
+		[]string{provider},
+		[]*http.Cookie{legacyCookie},
+		func(c *gin.Context) {
+			server.handleAgentMode(c)
+			if !c.Writer.Written() {
+				c.Status(http.StatusOK)
+			}
+		},
+	)
+
+	require.Equal(t, http.StatusTemporaryRedirect, firstResp.Code, firstResp.Body.String())
+	require.Equal(t, "/agent-mode", firstResp.Header().Get("Location"))
+
+	nextCookies := mergeCookies([]*http.Cookie{legacyCookie}, firstResp.Result().Cookies())
+	secondResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/agent-mode",
+		"/agent-mode",
+		[]string{provider},
+		nextCookies,
+		func(c *gin.Context) {
+			server.handleAgentMode(c)
+			if !c.Writer.Written() {
+				c.Status(http.StatusOK)
+			}
+		},
+	)
+
+	require.Equal(t, http.StatusOK, secondResp.Code, secondResp.Body.String())
+}
+
+func newTestCookieServer(t *testing.T, mode config.Mode, providers ...string) *Server {
+	t.Helper()
+
+	cfg := &config.Config{
+		Secret: "test-secret-0123456789abcdef0123456789abcdef",
+		Login: models.LoginConfig{
+			Endpoint: model.NewEndpoint("https://login.example.com"),
+		},
+	}
+	cfg.SetMode(mode)
+
+	for _, providerName := range providers {
+		provider := models.NewBaseProvider(
+			providerName,
+			models.ProviderConfig{
+				Name:     providerName,
+				Provider: "test",
+				Config:   &models.BasicConfig{},
+				Enabled:  true,
+			},
+			models.NewProviderCapabilities(),
+		)
+		provider.EnableCapability(models.ProviderCapabilityAuthorizer)
+		cfg.AddProvider(providerName, provider)
+	}
+
+	return &Server{
+		Config: cfg,
+	}
+}
+
+func performCookieHandlerRequest(
+	t *testing.T,
+	server *Server,
+	method string,
+	routePath string,
+	requestPath string,
+	providers []string,
+	requestCookies []*http.Cookie,
+	handler gin.HandlerFunc,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	cookieNames := []string{ThandCookieName}
+	for _, provider := range providers {
+		cookieNames = append(cookieNames, CreateCookieName(provider))
+	}
+
+	router.Use(ginsessions.SessionsMany(
+		cookieNames,
+		server.getSessionStore(server.Config.GetSecret()),
+	))
+	router.Handle(method, routePath, handler)
+
+	req := httptest.NewRequest(method, requestPath, nil)
+	for _, cookie := range requestCookies {
+		req.AddCookie(cookie)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func createVersionedCookieName(version, provider string) string {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(provider))
+	return fmt.Sprintf("%s_%s", version, encoded)
+}
+
+func newTestLocalSession(provider string, tokenLen int) *models.LocalSession {
+	token := repeatedToken("id", tokenLen)
+	accessToken := repeatedToken("access", tokenLen)
+	refreshToken := repeatedToken("refresh", tokenLen)
+
+	exportableSession := &models.ExportableSession{
+		Session: &models.Session{
+			UUID: uuid.New(),
+			User: &models.User{
+				ID:       "user-123",
+				Username: "test-user",
+				Email:    "test@example.com",
+				Name:     "Test User",
+				Source:   provider,
+			},
+			Token:        token,
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+			Expiry:       time.Now().UTC().Add(4 * time.Hour),
+		},
+		Provider: provider,
+	}
+
+	return exportableSession.ToLocalSession(newMockEncryptor())
+}
+
+func newLocalSessionForSignedCookieRange(
+	t *testing.T,
+	provider string,
+	secret string,
+	minSignedLen int,
+	maxSignedLen int,
+) *models.LocalSession {
+	t.Helper()
+
+	cookieName := createVersionedCookieName(testThandCookieV2, provider)
+	for tokenLen := 256; tokenLen <= 4096; tokenLen += 128 {
+		localSession := newTestLocalSession(provider, tokenLen)
+		signedValue := encodeProviderCookieValue(t, secret, cookieName, localSession)
+		if len(signedValue) >= minSignedLen && len(signedValue) <= maxSignedLen {
+			return localSession
+		}
+	}
+
+	t.Fatalf("failed to create local session for signed cookie range %d-%d", minSignedLen, maxSignedLen)
+	return nil
+}
+
+func repeatedToken(prefix string, targetLen int) string {
+	token := prefix
+	for len(token) < targetLen {
+		token += "-" + uuid.NewString()
+	}
+	return token[:targetLen]
+}
+
+func encodeProviderCookieValue(t *testing.T, secret string, cookieName string, localSession *models.LocalSession) string {
+	t.Helper()
+
+	codecs := secureCookieCodecs(secret, true)
+	value, err := securecookie.EncodeMulti(cookieName, localSession.GetEncodedLocalSession(), codecs...)
+	require.NoError(t, err)
+	return value
+}
+
+func encodeLegacyProviderCookieValue(t *testing.T, secret string, provider string, localSession *models.LocalSession) string {
+	t.Helper()
+
+	legacyCookieName := createVersionedCookieName(testThandCookieV1, provider)
+	codecs := secureCookieCodecs(secret, false)
+	value, err := securecookie.EncodeMulti(
+		legacyCookieName,
+		map[interface{}]interface{}{
+			ThandCookieAttributeSessionName: localSession.GetEncodedLocalSessionBytes(),
+		},
+		codecs...,
+	)
+	require.NoError(t, err)
+	return value
+}
+
+func encodeDefaultProviderCookieValue(t *testing.T, secret string, cookieName string, provider string) string {
+	t.Helper()
+
+	codecs := secureCookieCodecs(secret, false)
+	value, err := securecookie.EncodeMulti(
+		cookieName,
+		map[interface{}]interface{}{
+			ThandCookieAttributeActiveName: provider,
+		},
+		codecs...,
+	)
+	require.NoError(t, err)
+	return value
+}
+
+func secureCookieCodecs(secret string, unlimited bool) []securecookie.Codec {
+	codecs := securecookie.CodecsFromPairs([]byte(secret))
+	if unlimited {
+		for _, codec := range codecs {
+			if sc, ok := codec.(*securecookie.SecureCookie); ok {
+				sc.MaxLength(0)
+			}
+		}
+	}
+	return codecs
+}
+
+func shardProviderCookieValue(t *testing.T, cookieName, value string) []*http.Cookie {
+	t.Helper()
+
+	if len(value) <= providerCookieChunkSize {
+		return []*http.Cookie{
+			{
+				Name:  cookieName,
+				Value: value,
+				Path:  "/",
+			},
+		}
+	}
+
+	chunkCount := (len(value) + providerCookieChunkSize - 1) / providerCookieChunkSize
+	require.LessOrEqual(t, chunkCount, providerCookieMaxShards)
+
+	cookies := []*http.Cookie{
+		{
+			Name:  cookieName,
+			Value: fmt.Sprintf("chunks-%d", chunkCount),
+			Path:  "/",
+		},
+	}
+
+	for index := 0; index < chunkCount; index++ {
+		start := index * providerCookieChunkSize
+		end := start + providerCookieChunkSize
+		if end > len(value) {
+			end = len(value)
+		}
+
+		cookies = append(cookies, &http.Cookie{
+			Name:  fmt.Sprintf("%sC%d", cookieName, index+1),
+			Value: value[start:end],
+			Path:  "/",
+		})
+	}
+
+	return cookies
+}
+
+func cookiesByName(cookies []*http.Cookie) map[string]*http.Cookie {
+	result := make(map[string]*http.Cookie, len(cookies))
+	for _, cookie := range cookies {
+		result[cookie.Name] = cookie
+	}
+	return result
+}
+
+func assertCookiePresent(t *testing.T, cookies []*http.Cookie, name string) {
+	t.Helper()
+	byName := cookiesByName(cookies)
+	if _, ok := byName[name]; !ok {
+		t.Fatalf("expected cookie %s to be present", name)
+	}
+}
+
+func assertExpiredCookie(t *testing.T, cookies map[string]*http.Cookie, name string) {
+	t.Helper()
+
+	cookie, ok := cookies[name]
+	require.True(t, ok, "expected expired cookie %s to be set", name)
+	assert.True(
+		t,
+		cookie.MaxAge < 0 || (!cookie.Expires.IsZero() && cookie.Expires.Before(time.Now().Add(1*time.Minute))),
+		"expected cookie %s to be expired, got MaxAge=%d Expires=%s",
+		name,
+		cookie.MaxAge,
+		cookie.Expires,
+	)
+}
+
+func mergeCookies(base []*http.Cookie, updates []*http.Cookie) []*http.Cookie {
+	merged := make(map[string]*http.Cookie)
+	for _, cookie := range base {
+		merged[cookie.Name] = cookie
+	}
+
+	for _, cookie := range updates {
+		if cookie.MaxAge < 0 || (!cookie.Expires.IsZero() && cookie.Expires.Before(time.Now().Add(1*time.Minute))) {
+			delete(merged, cookie.Name)
+			continue
+		}
+		merged[cookie.Name] = cookie
+	}
+
+	result := make([]*http.Cookie, 0, len(merged))
+	for _, cookie := range merged {
+		result = append(result, cookie)
+	}
+	return result
+}
+
+func assertSessionsEqual(t *testing.T, expected *models.Session, actual *models.Session) {
+	t.Helper()
+
+	require.NotNil(t, expected)
+	require.NotNil(t, actual)
+	require.NotNil(t, expected.User)
+	require.NotNil(t, actual.User)
+
+	assert.Equal(t, expected.Token, actual.Token)
+	assert.Equal(t, expected.AccessToken, actual.AccessToken)
+	assert.Equal(t, expected.RefreshToken, actual.RefreshToken)
+	assert.Equal(t, expected.User.ID, actual.User.ID)
+	assert.Equal(t, expected.User.Email, actual.User.Email)
+	assert.Equal(t, expected.User.Name, actual.User.Name)
+	assert.True(t, expected.Expiry.Equal(actual.Expiry))
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -227,15 +227,7 @@ func (s *Server) Start() error {
 
 	router.Use(CORSMiddleware(corsConfig))
 
-	cookieNames := []string{ThandCookieName}
-
-	foundProviders := s.Config.GetProvidersByCapability(
-		models.ProviderCapabilityAuthorizer,
-	)
-
-	for providerName := range foundProviders {
-		cookieNames = append(cookieNames, CreateCookieName(providerName))
-	}
+	cookieNames := []string{ThandCookieName, ThandLegacyCookieName}
 
 	sessionStore := s.getSessionStore(s.GetConfig().GetSecret())
 	router.Use(sessions.SessionsMany(

--- a/internal/daemon/sessions.go
+++ b/internal/daemon/sessions.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/thand-io/agent/internal/common"
@@ -155,13 +154,7 @@ func (s *Server) postSession(c *gin.Context) {
 func (s *Server) getSessions(c *gin.Context) {
 
 	// Get the default provider from cookie
-	defaultProvider := ""
-	defaultCookie := sessions.DefaultMany(c, ThandCookieName)
-	if provider := defaultCookie.Get(ThandCookieAttributeActiveName); provider != nil {
-		if providerStr, ok := provider.(string); ok {
-			defaultProvider = providerStr
-		}
-	}
+	defaultProvider := s.getDefaultProviderCookieValue(c)
 
 	if s.Config.IsServer() {
 
@@ -364,11 +357,7 @@ func (s *Server) putSession(c *gin.Context) {
 	}
 
 	// Update the default provider cookie
-	defaultCookie := sessions.DefaultMany(c, ThandCookieName)
-	defaultCookie.Set(ThandCookieAttributeActiveName, provider)
-	err = defaultCookie.Save()
-
-	if err != nil {
+	if err := s.setDefaultProviderCookie(c, provider); err != nil {
 		s.getErrorPage(c, http.StatusInternalServerError, "Failed to save default provider", err)
 		return
 	}
@@ -407,26 +396,11 @@ func (s *Server) deleteSession(c *gin.Context) {
 		// Server mode: Clear all cookies for this provider
 
 		// Clear the provider-specific cookie
-		providerCookie := sessions.DefaultMany(c, CreateCookieName(provider))
-		providerCookie.Clear()
-		err := providerCookie.Save()
-
-		if err != nil {
-			s.getErrorPage(c, http.StatusInternalServerError, "Failed to clear provider cookie", err)
-			return
-		}
+		s.clearProviderCookies(c, provider)
 
 		// If this was the default provider, clear the default setting
-		defaultCookie := sessions.DefaultMany(c, ThandCookieName)
-		if activeProvider := defaultCookie.Get(ThandCookieAttributeActiveName); activeProvider != nil {
-			if activeProviderStr, ok := activeProvider.(string); ok && activeProviderStr == provider {
-				defaultCookie.Delete(ThandCookieAttributeActiveName)
-				err = defaultCookie.Save()
-				if err != nil {
-					s.getErrorPage(c, http.StatusInternalServerError, "Failed to clear default provider", err)
-					return
-				}
-			}
+		if s.getDefaultProviderCookieValue(c) == provider {
+			s.clearDefaultProviderCookies(c)
 		}
 
 		c.JSON(http.StatusOK, gin.H{
@@ -481,25 +455,11 @@ func (s *Server) deleteSessions(c *gin.Context) {
 
 		// Clear provider-specific cookies for each session
 		for providerName := range remoteSessions {
-			providerCookie := sessions.DefaultMany(c, CreateCookieName(providerName))
-			providerCookie.Clear()
-			err := providerCookie.Save()
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"provider": providerName,
-					"error":    err,
-				}).Warnln("Failed to clear provider cookie")
-			}
+			s.clearProviderCookies(c, providerName)
 		}
 
 		// Clear the default provider setting
-		defaultCookie := sessions.DefaultMany(c, ThandCookieName)
-		defaultCookie.Clear()
-		err = defaultCookie.Save()
-		if err != nil {
-			s.getErrorPage(c, http.StatusInternalServerError, "Failed to clear default cookie", err)
-			return
-		}
+		s.clearDefaultProviderCookies(c)
 
 		c.JSON(http.StatusOK, gin.H{
 			"message": "All sessions deleted successfully",


### PR DESCRIPTION
## Summary

This supersedes #296.

Provider `LocalSession` cookies can exceed practical browser cookie limits once the encoded session payload is wrapped by `securecookie`, especially for OAuth2 providers that issue large access or refresh tokens. Instead of dropping token material from persisted sessions, this PR moves provider cookies to a versioned v2 sharded transport so the browser transport can grow within a bounded budget while preserving the underlying session contents needed for refresh and validation flows.

---

## Type of Change

- [x] `fix` – Bug fix (patch version bump)
- [ ] `feat` – New feature (minor version bump)
- [ ] `refactor` – Code refactoring, no functional change
- [ ] `docs` – Documentation only
- [x] `test` – Adding or updating tests
- [ ] `chore` – Build, CI, dependency updates
- [ ] `major` / `BREAKING CHANGE` – Breaking change (major version bump)

---

## What Changed

- Added a versioned `_thand_v2` provider-cookie transport that signs the full provider session once and stores it either as a single cookie or as bounded shard cookies.
- Preserved `Token`, `AccessToken`, and `RefreshToken` in the stored `LocalSession` payload instead of dropping them to get under cookie limits.
- Added legacy `_thand_v1` read compatibility, v2-first rollout behavior, stale-shard cleanup, and fail-closed handling for partial or corrupt v2 cookie sets.
- Added read-side size guards before `securecookie.DecodeMulti` so oversized base values or shards are rejected before deeper decode work.
- Updated logout / delete / agent-sync behavior to clear legacy and v2 provider/default cookies and to migrate legacy agent/browser state without redirect loops.
- Added focused daemon coverage for large-session round-trips, v1 fallback, partial-cookie rejection, stale-shard cleanup, bounded-read rejection, logout/delete cleanup, and agent-mode migration.
- Added `go.work.sum` to `.gitignore` to avoid workspace noise during local development.

---

## Security Considerations

- [ ] No security impact
- [x] Reviewed for least-privilege impact
- [ ] Access grant / revocation logic reviewed
- [x] Audit trail is preserved for any new access paths
- [x] No credentials, tokens, or secrets introduced in code or config

**Security notes**:

- The full provider payload is signed before sharding, so shard tampering still fails `securecookie` verification.
- The v2 read path fails closed on partial or corrupt cookies and only falls back to v1 when v2 is absent.
- Read-side bounds are enforced before `securecookie.DecodeMulti` to avoid accepting cookie shapes we would never emit ourselves.
- OAuth token fields remain in the persisted session payload by design; this restores correctness for refresh/validation paths that would fail if tokens were dropped.

---

## Testing

- [x] Unit tests pass (`go test ./...`)
- [ ] Functional tests pass
- [ ] Integration tests pass
- [x] Manually tested locally — describe scenario below

**Manual test scenario**:

```bash
# Focused daemon slice used for TDD red/green capture
go test ./internal/daemon -run 'TestProviderCookie|TestAuthCookie|TestHandleAgentMode|TestDeleteSession|TestGetLogoutPage' -v

# Final verification
go test ./internal/daemon ./internal/config/services/encrypt -v
go test ./...
```

TDD progression:
- Added focused daemon tests first for large provider sessions, legacy fallback, partial-cookie rejection, stale-shard cleanup, bounded read rejection, logout/delete cleanup, and agent-mode migration.
- Verified the focused daemon slice was red before the sharding implementation and guardrails were complete.
- Re-ran the same focused daemon slice after implementation; it is green along with the broader regression suite above.

---

## Breaking Changes

- [ ] This PR does **not** introduce breaking changes
- [x] This PR **does** introduce breaking changes (describe below)

---

## Documentation

- [ ] No documentation changes needed
- [x] In-code comments updated
- [ ] `docs/` updated
- [ ] `README.md` updated
- [ ] Config examples updated

---

## Open Question

Server↔agent compatibility should remain intact because the callback and session-manager handoff still use the unchanged `LocalSession` wire format.

__The remaining rollout question is mixed old/new **server** nodes sharing one browser cookie domain:__

- Should deployment require a no-mixed-server rollout on the shared cookie domain?
- Or do we want a separate follow-up compatibility release with temporary dual-write / broader read compatibility for mixed server fleets?

Current recommendation: prefer the simpler operational constraint rather than adding more cookie-protocol complexity in this fix.

---

## Checklist

- [x] My branch is up to date with `main`
- [x] Commit messages follow the [conventional commit format](RELEASE.md) (`feat:`, `fix:`, `major:`, etc.)
- [x] No debug code, hardcoded values, or temporary workarounds left in
- [x] All new code has appropriate test coverage
- [x] I have reviewed my own diff before requesting review
