### PR TITLE
fix: tighten provider cookie shard handling

### DIFF
--- a/internal/daemon/cookies.go
+++ b/internal/daemon/cookies.go
@@ -230,7 +230,9 @@ func (s *Server) writeProviderCookie(c *gin.Context, provider string, localSessi
 		return fmt.Errorf("signed provider session exceeds bounded cookie/header budget")
 	}
 
-	s.clearCookieSetFromRequest(c, cookieName)
+	writtenCookieNames := map[string]struct{}{
+		cookieName: {},
+	}
 
 	if chunkCount <= 1 {
 		s.setCookieValue(c, cookieName, signedValue)
@@ -249,9 +251,11 @@ func (s *Server) writeProviderCookie(c *gin.Context, provider string, localSessi
 				fmt.Sprintf("%sC%d", cookieName, shard+1),
 				signedValue[start:end],
 			)
+			writtenCookieNames[fmt.Sprintf("%sC%d", cookieName, shard+1)] = struct{}{}
 		}
 	}
 
+	s.clearStaleCookieSetFromRequest(c, cookieName, writtenCookieNames)
 	s.clearCookieByName(c, CreateLegacyCookieName(provider))
 	return nil
 }
@@ -304,18 +308,16 @@ func (s *Server) readCurrentProviderCookieValue(
 		return "", false, nil
 	}
 
+	if len(cookie.Value) > providerCookieChunkSize {
+		return "", true, fmt.Errorf("provider cookie base value exceeds shard limit")
+	}
+
 	if !strings.HasPrefix(cookie.Value, providerCookieChunkPrefix) {
-		if len(cookie.Value) > providerCookieChunkSize {
-			return "", true, fmt.Errorf("provider cookie base value exceeds shard limit")
-		}
 		return cookie.Value, true, nil
 	}
 
 	shardCount, err := strconv.Atoi(strings.TrimPrefix(cookie.Value, providerCookieChunkPrefix))
 	if err != nil {
-		if len(cookie.Value) > providerCookieChunkSize {
-			return "", true, fmt.Errorf("provider cookie base value exceeds shard limit")
-		}
 		return cookie.Value, true, nil
 	}
 	if shardCount <= 0 || shardCount > providerCookieMaxShards {
@@ -410,6 +412,33 @@ func getLocalSessionFromCookieData(sessionData any) (*models.LocalSession, error
 func (s *Server) clearProviderCookies(c *gin.Context, provider string) {
 	s.clearCookieSetFromRequest(c, CreateCookieName(provider))
 	s.clearCookieByName(c, CreateLegacyCookieName(provider))
+}
+
+// clearStaleCookieSetFromRequest expires request cookies in the provider cookie
+// set that are not being rewritten in the current response. This avoids sending
+// redundant expire+rewrite headers for the same cookie name.
+func (s *Server) clearStaleCookieSetFromRequest(c *gin.Context, baseCookieName string, keepNames map[string]struct{}) {
+	names := map[string]struct{}{}
+
+	for _, cookie := range c.Request.Cookies() {
+		if cookie == nil {
+			continue
+		}
+
+		if cookie.Name != baseCookieName && !strings.HasPrefix(cookie.Name, baseCookieName+"C") {
+			continue
+		}
+
+		if _, keep := keepNames[cookie.Name]; keep {
+			continue
+		}
+
+		names[cookie.Name] = struct{}{}
+	}
+
+	for name := range names {
+		s.clearCookieByName(c, name)
+	}
 }
 
 // clearCookieSetFromRequest expires the named base cookie plus any shard cookies

--- a/internal/daemon/provider_cookies_test.go
+++ b/internal/daemon/provider_cookies_test.go
@@ -1017,7 +1017,7 @@ func mergeCookies(base []*http.Cookie, updates []*http.Cookie) []*http.Cookie {
 	}
 
 	for _, cookie := range updates {
-		if cookie.MaxAge < 0 || (!cookie.Expires.IsZero() && cookie.Expires.Before(time.Now().Add(1*time.Minute))) {
+		if isExpiredCookie(cookie) {
 			delete(merged, cookie.Name)
 			continue
 		}

--- a/internal/daemon/provider_cookies_test.go
+++ b/internal/daemon/provider_cookies_test.go
@@ -86,12 +86,11 @@ func TestAuthCookieCleansStaleV2ShardsWhenSessionShrinks(t *testing.T) {
 	provider := "oauth2-shrink"
 	server := newTestCookieServer(t, config.ModeServer, provider)
 
-	largeSession := newLocalSessionForSignedCookieRange(
+	largeSession := newLocalSessionForExactShardCount(
 		t,
 		provider,
 		server.Config.GetSecret(),
-		providerCookieChunkSize+1,
-		providerCookieChunkSize*providerCookieMaxShards,
+		providerCookieMaxShards,
 	)
 	smallSession := newTestLocalSession(provider, 32)
 
@@ -133,8 +132,79 @@ func TestAuthCookieCleansStaleV2ShardsWhenSessionShrinks(t *testing.T) {
 
 	require.Equal(t, http.StatusNoContent, secondResp.Code, secondResp.Body.String())
 
-	responseCookies := cookiesByName(secondResp.Result().Cookies())
-	assertExpiredCookie(t, responseCookies, CreateCookieName(provider)+"C1")
+	responseCookies := secondResp.Result().Cookies()
+	assertNoExpiredCookieHeaders(t, responseCookies, CreateCookieName(provider))
+	for shard := 1; shard <= providerCookieMaxShards; shard++ {
+		assertExpiredCookieCount(t, responseCookies, fmt.Sprintf("%sC%d", CreateCookieName(provider), shard), 1)
+	}
+}
+
+func TestAuthCookieRewritingSameWidthShardSetDoesNotExpireRewrittenNames(t *testing.T) {
+	provider := "oauth2-rewrite"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+
+	firstSession := newLocalSessionForExactShardCount(
+		t,
+		provider,
+		server.Config.GetSecret(),
+		2,
+	)
+	secondSession := newLocalSessionForExactShardCount(
+		t,
+		provider,
+		server.Config.GetSecret(),
+		2,
+	)
+
+	firstResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth-cookie",
+		"/auth-cookie",
+		[]string{provider},
+		nil,
+		func(c *gin.Context) {
+			if err := server.setAuthCookie(c, provider, firstSession); err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
+				return
+			}
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, firstResp.Code, firstResp.Body.String())
+
+	secondResp := performCookieHandlerRequest(
+		t,
+		server,
+		http.MethodGet,
+		"/auth-cookie",
+		"/auth-cookie",
+		[]string{provider},
+		mergeCookies(nil, firstResp.Result().Cookies()),
+		func(c *gin.Context) {
+			if err := server.setAuthCookie(c, provider, secondSession); err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
+				return
+			}
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	require.Equal(t, http.StatusNoContent, secondResp.Code, secondResp.Body.String())
+
+	responseCookies := secondResp.Result().Cookies()
+	assertNoExpiredCookieHeaders(
+		t,
+		responseCookies,
+		CreateCookieName(provider),
+		CreateCookieName(provider)+"C1",
+		CreateCookieName(provider)+"C2",
+	)
+	assertCookieCount(t, responseCookies, CreateCookieName(provider), 1)
+	assertCookieCount(t, responseCookies, CreateCookieName(provider)+"C1", 1)
+	assertCookieCount(t, responseCookies, CreateCookieName(provider)+"C2", 1)
 }
 
 func TestProviderCookieReassemblesV2ShardedSession(t *testing.T) {
@@ -390,6 +460,24 @@ func TestReadCurrentProviderCookieValueRejectsOversizedUnshardedBase(t *testing.
 	req.AddCookie(&http.Cookie{
 		Name:  v2CookieName,
 		Value: repeatedToken("oversized-base", providerCookieChunkSize+1),
+	})
+
+	value, found, err := server.readCurrentProviderCookieValue(req, v2CookieName)
+	require.True(t, found)
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "provider cookie base value exceeds shard limit")
+}
+
+func TestReadCurrentProviderCookieValueRejectsOversizedChunksPrefixedBase(t *testing.T) {
+	provider := "oauth2-read-oversized-chunks-prefix"
+	server := newTestCookieServer(t, config.ModeServer, provider)
+	v2CookieName := createVersionedCookieName(testThandCookieV2, provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider-cookie", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  v2CookieName,
+		Value: providerCookieChunkPrefix + repeatedToken("1", providerCookieChunkSize),
 	})
 
 	value, found, err := server.readCurrentProviderCookieValue(req, v2CookieName)
@@ -728,6 +816,28 @@ func newLocalSessionForSignedCookieRange(
 	return nil
 }
 
+func newLocalSessionForExactShardCount(
+	t *testing.T,
+	provider string,
+	secret string,
+	shardCount int,
+) *models.LocalSession {
+	t.Helper()
+
+	cookieName := createVersionedCookieName(testThandCookieV2, provider)
+	for tokenLen := 256; tokenLen <= 4096; tokenLen += 128 {
+		localSession := newTestLocalSession(provider, tokenLen)
+		signedValue := encodeProviderCookieValue(t, secret, cookieName, localSession)
+		actualShardCount := max(1, (len(signedValue)+providerCookieChunkSize-1)/providerCookieChunkSize)
+		if actualShardCount == shardCount {
+			return localSession
+		}
+	}
+
+	t.Fatalf("failed to create local session for exact shard count %d", shardCount)
+	return nil
+}
+
 func repeatedToken(prefix string, targetLen int) string {
 	token := prefix
 	for len(token) < targetLen {
@@ -837,12 +947,26 @@ func cookiesByName(cookies []*http.Cookie) map[string]*http.Cookie {
 	return result
 }
 
+func findCookiesByName(cookies []*http.Cookie, name string) []*http.Cookie {
+	result := []*http.Cookie{}
+	for _, cookie := range cookies {
+		if cookie.Name == name {
+			result = append(result, cookie)
+		}
+	}
+	return result
+}
+
 func assertCookiePresent(t *testing.T, cookies []*http.Cookie, name string) {
 	t.Helper()
 	byName := cookiesByName(cookies)
 	if _, ok := byName[name]; !ok {
 		t.Fatalf("expected cookie %s to be present", name)
 	}
+}
+
+func isExpiredCookie(cookie *http.Cookie) bool {
+	return cookie.MaxAge < 0 || (!cookie.Expires.IsZero() && cookie.Expires.Before(time.Now().Add(1*time.Minute)))
 }
 
 func assertExpiredCookie(t *testing.T, cookies map[string]*http.Cookie, name string) {
@@ -852,12 +976,38 @@ func assertExpiredCookie(t *testing.T, cookies map[string]*http.Cookie, name str
 	require.True(t, ok, "expected expired cookie %s to be set", name)
 	assert.True(
 		t,
-		cookie.MaxAge < 0 || (!cookie.Expires.IsZero() && cookie.Expires.Before(time.Now().Add(1*time.Minute))),
+		isExpiredCookie(cookie),
 		"expected cookie %s to be expired, got MaxAge=%d Expires=%s",
 		name,
 		cookie.MaxAge,
 		cookie.Expires,
 	)
+}
+
+func assertCookieCount(t *testing.T, cookies []*http.Cookie, name string, count int) {
+	t.Helper()
+	assert.Len(t, findCookiesByName(cookies, name), count, "expected %d Set-Cookie headers for %s", count, name)
+}
+
+func assertExpiredCookieCount(t *testing.T, cookies []*http.Cookie, name string, count int) {
+	t.Helper()
+
+	expiredCount := 0
+	for _, cookie := range findCookiesByName(cookies, name) {
+		if isExpiredCookie(cookie) {
+			expiredCount++
+		}
+	}
+
+	assert.Equal(t, count, expiredCount, "expected %d expired Set-Cookie headers for %s", count, name)
+}
+
+func assertNoExpiredCookieHeaders(t *testing.T, cookies []*http.Cookie, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		assertExpiredCookieCount(t, cookies, name, 0)
+	}
 }
 
 func mergeCookies(base []*http.Cookie, updates []*http.Cookie) []*http.Cookie {


### PR DESCRIPTION
## Summary

Follow-up to #310 to address the two merged review comments on the provider-cookie sharding change.

---

## Type of Change

- [x] `fix` – Bug fix (patch version bump)
- [x] `test` – Adding or updating tests

---

## What Changed

- Expire only stale v2 provider-cookie shard names during rewrites instead of clearing and rewriting the full current shard set.
- Hoist the v2 base-cookie size guard ahead of `chunks-N` parsing so the bounded input contract is explicit in the read path.
- Add daemon tests covering same-width sharded rewrites, stale-shard cleanup on shrink, and oversized `chunks-*` base-cookie rejection.

---

## Security Considerations

- [ ] No security impact
- [x] Reviewed for least-privilege impact
- [ ] Access grant / revocation logic reviewed
- [ ] Audit trail is preserved for any new access paths
- [x] No credentials, tokens, or secrets introduced in code or config

**Security notes** *(if applicable)*:

- The read-path change keeps the existing bounded-cookie contract explicit before `securecookie` decoding.
- The rewrite-path change reduces redundant `Set-Cookie` headers for large sharded sessions, which lowers response-header bloat without widening accepted cookie shapes.

---

## Testing

- [x] Unit tests pass (`go test ./...`)
- [ ] Functional tests pass
- [ ] Integration tests pass
- [ ] Manually tested locally — describe scenario below

**Manual test scenario** *(if applicable)*:

```bash
go test ./internal/daemon -run 'TestAuthCookie(RewritingSameWidthShardSetDoesNotExpireRewrittenNames|CleansStaleV2ShardsWhenSessionShrinks)|TestReadCurrentProviderCookieValueRejectsOversized(ChunksPrefixedBase|UnshardedBase)' -v
go test ./internal/daemon -run 'TestProviderCookie|TestAuthCookie|TestHandleAgentMode|TestDeleteSession|TestGetLogoutPage' -v
go test ./internal/daemon ./internal/config/services/encrypt -v
go test ./...
```

---

## Breaking Changes

- [x] This PR does **not** introduce breaking changes
- [ ] This PR **does** introduce breaking changes (describe below)

---

## Documentation

- [x] No documentation changes needed
- [ ] In-code comments updated
- [ ] `docs/` updated
- [ ] `README.md` updated
- [ ] Config examples updated

---

## Checklist

- [x] My branch is up to date with `main`
- [x] Commit messages follow the [conventional commit format](RELEASE.md) (`feat:`, `fix:`, `major:`, etc.)
- [x] No debug code, hardcoded values, or temporary workarounds left in
- [x] All new code has appropriate test coverage
- [x] I have reviewed my own diff before requesting review
