### PR TITLE
[codex] Fix Temporal bootstrap binding in testinfra

### DIFF
--- a/test/integration/testinfra/infrastructure.go
+++ b/test/integration/testinfra/infrastructure.go
@@ -22,7 +22,9 @@ import (
 	"github.com/thand-io/agent/internal/common"
 	sdkConstants "github.com/thand-io/agent/sdk/constants"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"go.temporal.io/api/enums/v1"
@@ -370,6 +372,7 @@ system.forceSearchAttributesCacheRefreshOnRead:
 		Env: map[string]string{
 			"DB":                       "postgres12",
 			"DB_PORT":                  "5432",
+			"BIND_ON_IP":               "0.0.0.0",
 			"POSTGRES_USER":            "temporal",
 			"POSTGRES_PWD":             "temporal",
 			"POSTGRES_SEEDS":           postgresIP,
@@ -491,7 +494,7 @@ func (infra *TestInfrastructure) registerNamespaceWithSearchAttributes(ctx conte
 	workflowClient := workflowservice.NewWorkflowServiceClient(conn)
 	operatorClient := operatorservice.NewOperatorServiceClient(conn)
 
-	// Register the namespace
+	// Register the namespace directly. Unexpected bootstrap failures should fail fast.
 	_, err = workflowClient.RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        TemporalTestNamespace,
 		Description:                      "Integration test namespace for thand agent",
@@ -522,10 +525,14 @@ func (infra *TestInfrastructure) registerNamespaceWithSearchAttributes(ctx conte
 		searchAttributes[attr.GetName()] = attr.GetValueType()
 	}
 
-	// Add all search attributes in a single call
-	_, err = operatorClient.AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
-		Namespace:        TemporalTestNamespace,
-		SearchAttributes: searchAttributes,
+	// Temporal can briefly lag namespace visibility after registration, so allow a
+	// short retry window for this follow-up call only.
+	err = retryAddSearchAttributesUntilNamespaceVisible(ctx, func(callCtx context.Context) error {
+		_, err := operatorClient.AddSearchAttributes(callCtx, &operatorservice.AddSearchAttributesRequest{
+			Namespace:        TemporalTestNamespace,
+			SearchAttributes: searchAttributes,
+		})
+		return err
 	})
 	require.NoError(infra.t, err, "Failed to add search attributes to namespace")
 
@@ -544,6 +551,45 @@ func (infra *TestInfrastructure) TemporalHostPort() (string, int) {
 	port := 7233
 	fmt.Sscanf(portStr, "%d", &port)
 	return host, port
+}
+
+func retryAddSearchAttributesUntilNamespaceVisible(ctx context.Context, op func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	const (
+		pollInterval = 250 * time.Millisecond
+		rpcTimeout   = 3 * time.Second
+	)
+
+	var lastErr error
+	for {
+		callCtx, callCancel := context.WithTimeout(ctx, rpcTimeout)
+		lastErr = op(callCtx)
+		callCancel()
+		if lastErr == nil {
+			return nil
+		}
+
+		if !isNamespaceNotVisibleError(lastErr) {
+			return lastErr
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for Temporal namespace visibility: %w", lastErr)
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func isNamespaceNotVisibleError(err error) bool {
+	if status.Code(err) == codes.NotFound {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "namespace") && strings.Contains(message, "not found")
 }
 
 // Testing returns the *testing.T associated with this infrastructure.

--- a/test/integration/testinfra/infrastructure.go
+++ b/test/integration/testinfra/infrastructure.go
@@ -6,6 +6,7 @@ package testinfra
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -29,6 +30,7 @@ import (
 
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 )
@@ -584,12 +586,17 @@ func retryAddSearchAttributesUntilNamespaceVisible(ctx context.Context, op func(
 }
 
 func isNamespaceNotVisibleError(err error) bool {
-	if status.Code(err) == codes.NotFound {
+	if err == nil {
+		return false
+	}
+
+	var namespaceNotFound *serviceerror.NamespaceNotFound
+	if errors.As(err, &namespaceNotFound) {
 		return true
 	}
 
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "namespace") && strings.Contains(message, "not found")
+	convertedErr := serviceerror.FromStatus(serviceerror.ToStatus(err))
+	return errors.As(convertedErr, &namespaceNotFound) || status.Code(err) == codes.NotFound
 }
 
 // Testing returns the *testing.T associated with this infrastructure.

--- a/test/integration/testinfra/infrastructure_test.go
+++ b/test/integration/testinfra/infrastructure_test.go
@@ -1,0 +1,55 @@
+package testinfra
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsNamespaceNotVisibleError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "temporal namespace not found",
+			err:  serviceerror.NewNamespaceNotFound(TemporalTestNamespace),
+			want: true,
+		},
+		{
+			name: "grpc not found",
+			err:  status.Error(codes.NotFound, "namespace unavailable"),
+			want: true,
+		},
+		{
+			name: "generic error text is ignored",
+			err:  errors.New("namespace thand-test not found"),
+			want: false,
+		},
+		{
+			name: "grpc unavailable is not retried",
+			err:  status.Error(codes.Unavailable, "transport unavailable"),
+			want: false,
+		},
+		{
+			name: "grpc deadline exceeded is not retried",
+			err:  status.Error(codes.DeadlineExceeded, "deadline exceeded"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isNamespaceNotVisibleError(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- bind the Temporal auto-setup container on `0.0.0.0` instead of the image default loopback-only bind
- keep namespace registration fail-fast
- narrow retries so they only cover the short namespace-visibility lag before `AddSearchAttributes`

## Why this was needed on my setup

The frontend integration topology does not talk to Temporal from inside the Temporal container. It starts a separate Thand server container and points that container at Temporal through a host-published port using `host.docker.internal`.

On my local setup (`Darwin` / Apple Silicon / Docker Desktop), that access path exposed the fact that Temporal was only listening on loopback inside its own container. In that state the service can look superficially started, but it is not reliably reachable from the sibling Thand container via the host-published port.

Other environments were likely getting away with this because their container runtime and port-forwarding behavior was more permissive, especially on plain Linux and GitHub CI. This change makes the bind explicit and portable instead of depending on environment-specific forwarding quirks.

## Root Cause

After reproducing locally, the actual problem turned out to be the Temporal container needed to bind on an externally reachable interface for this test topology.

The remaining retry is intentionally tiny and scoped only to the follow-up `AddSearchAttributes` call, where Temporal can briefly lag namespace visibility after a successful namespace registration.

## Validation

- `make test-e2e`
