### PR TITLE
chore: bump serverless-sdk-go replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/thand-io/agent
 go 1.26.0
 
 // replace github.com/serverlessworkflow/sdk-go/v3 => ../serverless-sdk-go
-replace github.com/serverlessworkflow/sdk-go/v3 => github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260105154148-a507840f0238
+replace github.com/serverlessworkflow/sdk-go/v3 => github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260419080432-757a53137239
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,8 @@ github.com/hashicorp/vault/api v1.23.0 h1:gXgluBsSECfRWTSW9niY2jwg2e9mMJc4WoHNv4
 github.com/hashicorp/vault/api v1.23.0/go.mod h1:zransKiB9ftp+kgY8ydjnvCU7Wk8i9L0DYWpXeMj9ko=
 github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260105154148-a507840f0238 h1:M+qq3zO76q6VBNnMzE5XwlXzEVSn5Ryn61pKrxv8x0I=
 github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260105154148-a507840f0238/go.mod h1:N/TVPogY5OsZ+NG7NeD9oZ30VO6oHahxAsoeBPnh/Nw=
+github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260419080432-757a53137239 h1:eJmhFw6pYkw7KE/F/sfXadqa7UBXamU2x6uaA5wcY5M=
+github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260419080432-757a53137239/go.mod h1:N/TVPogY5OsZ+NG7NeD9oZ30VO6oHahxAsoeBPnh/Nw=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module github.com/thand-io/agent/test
 go 1.26.0
 
 // replace github.com/serverlessworkflow/sdk-go/v3 => ../../serverless-sdk-go
-replace github.com/serverlessworkflow/sdk-go/v3 => github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260105154148-a507840f0238
+replace github.com/serverlessworkflow/sdk-go/v3 => github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260419080432-757a53137239
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/test/go.sum
+++ b/test/go.sum
@@ -371,6 +371,8 @@ github.com/hashicorp/vault/api v1.23.0 h1:gXgluBsSECfRWTSW9niY2jwg2e9mMJc4WoHNv4
 github.com/hashicorp/vault/api v1.23.0/go.mod h1:zransKiB9ftp+kgY8ydjnvCU7Wk8i9L0DYWpXeMj9ko=
 github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260105154148-a507840f0238 h1:M+qq3zO76q6VBNnMzE5XwlXzEVSn5Ryn61pKrxv8x0I=
 github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260105154148-a507840f0238/go.mod h1:N/TVPogY5OsZ+NG7NeD9oZ30VO6oHahxAsoeBPnh/Nw=
+github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260419080432-757a53137239 h1:eJmhFw6pYkw7KE/F/sfXadqa7UBXamU2x6uaA5wcY5M=
+github.com/hughneale/serverless-sdk-go/v3 v3.0.0-20260419080432-757a53137239/go.mod h1:N/TVPogY5OsZ+NG7NeD9oZ30VO6oHahxAsoeBPnh/Nw=
 github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
 github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
 github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=


### PR DESCRIPTION
## Summary

Bump the `github.com/hughneale/serverless-sdk-go/v3` replacement to the latest fork commit in both module manifests.

This pulls in four upstream commits:
- `51bf79d` - `Add pullPolicy to run container model (#253)`
- `97cab1a` - `Fix task decode precedence for custom tasks`
- `49008de` - `Merge pull request #1 from michaelw/mw/task-decode-custom-precedence`
- `757a531` - `Merge pull request #2 from hughneale/proxy-auth-support`

The previous pinned commit `a507840f0238` is the merge-base of the new target `757a53137239`, and the compare is `ahead_by=4`, `behind_by=0`, so this update is a clean fast-forward and does not drop any previously included fixes.

---

## Type of Change

- [ ] `feat` – New feature (minor version bump)
- [ ] `fix` – Bug fix (patch version bump)
- [ ] `refactor` – Code refactoring, no functional change
- [ ] `docs` – Documentation only
- [ ] `test` – Adding or updating tests
- [x] `chore` – Build, CI, dependency updates
- [ ] `major` / `BREAKING CHANGE` – Breaking change (major version bump)

---

## What Changed

- Updated the `serverless-sdk-go` replacement in `go.mod` to `v3.0.0-20260419080432-757a53137239`
- Updated the matching replacement in `test/go.mod` and refreshed `go.sum` / `test/go.sum`
- Verified the old pin fast-forwards cleanly to the new target with no fixes lost

---

## Security Considerations

- [ ] No security impact
- [x] Reviewed for least-privilege impact
- [ ] Access grant / revocation logic reviewed
- [ ] Audit trail is preserved for any new access paths
- [x] No credentials, tokens, or secrets introduced in code or config

**Security notes** *(if applicable)*:

Dependency refresh only. No local credentials, tokens, or policy changes were introduced by this change.

---

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Functional tests pass
- [x] Integration tests pass
- [x] Manually tested locally — describe scenario below

**Manual test scenario** *(if applicable)*:

```bash
export GOCACHE=/tmp/codex-go-cache-032e GOMODCACHE=/tmp/codex-go-modcache-032e GOEXPERIMENT=jsonv2

pkgs=($(go list ./... | grep -v '/test/functional' | grep -v '/test/integration'))
go test -v -short $pkgs

cd test && go test -v -timeout 10m ./functional/...
cd test && go test -v -timeout 5m ./integration/services/...
cd test && go test -v -timeout 15m ./integration/workflows/...
cd /Users/michaelw/.codex/worktrees/032e/agent && make build-linux-amd64
cd /Users/michaelw/.codex/worktrees/032e/agent/test && CHROME_BIN="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" go test -v -timeout 30m ./integration/frontend/...
```

Verified the Brave-backed frontend flows complete successfully for the elevation approval scenarios after updating the SDK pin.

---

## Breaking Changes

- [x] This PR does **not** introduce breaking changes
- [ ] This PR **does** introduce breaking changes (describe below)

**Migration steps** *(if applicable)*:

---

## Documentation

- [x] No documentation changes needed
- [ ] In-code comments updated
- [ ] `docs/` updated
- [ ] `README.md` updated
- [ ] Config examples updated

---

## Checklist

- [x] My branch is up to date with `main`
- [x] Commit messages follow the [conventional commit format](RELEASE.md) (`feat:`, `fix:`, `major:`, etc.)
- [x] No debug code, hardcoded values, or temporary workarounds left in
- [x] All new code has appropriate test coverage
- [x] I have reviewed my own diff before requesting review
