### PR TITLE
docs: add repo-local agent policy and Temporal workflow guardrails

### DIFF
--- a/.agent-shared/skills/provider-or-workflow-change.md
+++ b/.agent-shared/skills/provider-or-workflow-change.md
@@ -1,0 +1,31 @@
+# Provider Or Workflow Change
+
+Use this skill when changing provider integrations, role resolution, workflow definitions, or the wiring that connects those pieces.
+
+## Required Inputs
+
+- Provider name, role name, or workflow name
+- Intended behavior change
+- Whether the change affects authorization, revocation, session handling, or examples/docs
+
+## Steps
+
+1. Identify the owning package and follow the existing pattern before adding new files:
+   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`, RBAC/auth/session helpers, and tests.
+   - Workflow-related behavior is usually wired through `internal/workflows/`, `internal/config/workflows.go`, and `internal/config/temporal*.go`.
+2. Trace registration and config loading, not just the leaf implementation:
+   - `internal/providers/registry.go`
+   - `internal/config/providers.go`
+   - `internal/config/roles.go`
+   - `internal/config/workflows.go`
+   - `config.example.yaml`, `examples/providers/`, `examples/roles/`, `examples/workflows/`
+3. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal activity boundaries.
+4. Add or update tests in the nearest package, then choose the matching nested `test/` suite if runtime behavior changed.
+5. Update docs/examples whenever a user would need to configure or invoke the new behavior differently.
+6. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md` and `sdk/workflows/` before finalizing.
+
+## Completion Criteria
+
+- Registration, config, examples, and docs are consistent with the implementation.
+- Grant/revoke or start/stop behavior is covered, not just creation.
+- Appropriate package and integration tests are updated or explicitly deferred.

--- a/.agent-shared/skills/provider-or-workflow-change.md
+++ b/.agent-shared/skills/provider-or-workflow-change.md
@@ -1,6 +1,7 @@
 # Provider Or Workflow Change
 
-Use this skill when changing provider integrations, role resolution, workflow definitions, or the wiring that connects those pieces.
+Use this skill when changing provider integrations, role resolution, workflow definitions, or the
+wiring that connects those pieces.
 
 ## Required Inputs
 
@@ -11,18 +12,28 @@ Use this skill when changing provider integrations, role resolution, workflow de
 ## Steps
 
 1. Identify the owning package and follow the existing pattern before adding new files:
-   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`, RBAC/auth/session helpers, and tests.
-   - Workflow-related behavior is usually wired through `internal/workflows/`, `internal/config/workflows.go`, and `internal/config/temporal*.go`.
+   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`,
+     RBAC/auth/session helpers, and tests.
+   - Workflow-related behavior is usually wired through `internal/workflows/`,
+     `internal/config/workflows.go`, and `internal/config/temporal*.go`.
 2. Trace registration and config loading, not just the leaf implementation:
    - `internal/providers/registry.go`
    - `internal/config/providers.go`
    - `internal/config/roles.go`
    - `internal/config/workflows.go`
    - `config.example.yaml`, `examples/providers/`, `examples/roles/`, `examples/workflows/`
-3. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal activity boundaries.
-4. Add or update tests in the nearest package, then choose the matching nested `test/` suite if runtime behavior changed.
-5. Update docs/examples whenever a user would need to configure or invoke the new behavior differently.
-6. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md` and `sdk/workflows/` before finalizing.
+3. If the change touches Temporal Workflow Definitions, Activities, local activities, message
+   handlers, retries, or versioning, use the `temporal-development` skill for the detailed
+   determinism, handler-safety, and compatibility checklist.
+4. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal
+   activity boundaries.
+5. Add or update tests in the nearest package, then choose the matching nested `test/` suite if
+   runtime behavior changed. For Go Workflow Definition changes, include replay testing and
+   `workflowcheck` per `temporal-development` when practical.
+6. Update docs/examples whenever a user would need to configure or invoke the new behavior
+   differently.
+7. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md`
+   and `sdk/workflows/` before finalizing.
 
 ## Completion Criteria
 

--- a/.agent-shared/skills/public-surface-change.md
+++ b/.agent-shared/skills/public-surface-change.md
@@ -1,0 +1,27 @@
+# Public Surface Change
+
+Use this skill when a change alters user-facing CLI behavior, HTTP/API behavior, config shape, examples, docs, or release/build semantics.
+
+## Required Inputs
+
+- The user-facing surface that changed
+- The implementation files that drove the change
+
+## Steps
+
+1. Identify the public surface:
+   - CLI: `cmd/cli/`, `cmd/cli/README.md`, `README.md`, `docs/configuration/cli.md`
+   - API/server: `internal/daemon/`, `internal/api/`, `docs/api/`, `docs/swagger.json`, `docs/swagger.yaml`, `docs/docs.go`
+   - Config/examples: `config.example.yaml`, `examples/`, `docs/configuration/`
+   - Release/build/docs tooling: `Makefile`, `Dockerfile*`, `.github/workflows/`, `RELEASE.md`, `docs/`
+2. Update the code and the user-facing description in the same change whenever possible.
+3. If API annotations changed, regenerate Swagger assets with `make swagger`.
+4. If config keys, workflow examples, or provider examples changed, update `config.example.yaml`, the matching `examples/` file, and the relevant docs page together.
+5. If docs-site content changed, run `cd docs && bundle exec jekyll build`.
+6. If release or CI semantics changed, verify the impacted workflow file and `RELEASE.md` stay aligned.
+
+## Completion Criteria
+
+- Code and user-facing docs/examples/config describe the same behavior.
+- Generated docs artifacts are refreshed when needed.
+- Verification covers both the implementation and the public surface.

--- a/.agent-shared/skills/repo-orientation.md
+++ b/.agent-shared/skills/repo-orientation.md
@@ -1,0 +1,29 @@
+# Repo Orientation
+
+Use this skill when you are entering the repo for a new task, the request spans multiple packages, or you need to map a change to the owning subsystem before editing.
+
+## Required Inputs
+
+- The task statement
+- Any known file paths or package names
+
+## Steps
+
+1. Read `README.md`, `Makefile`, and `config.example.yaml`.
+2. Map the request to the main surfaces:
+   - CLI and startup flow: `main.go`, `cmd/cli/`
+   - Server/API: `internal/daemon/`, `internal/api/`
+   - Config/bootstrap: `internal/config/`
+   - Providers and RBAC: `internal/providers/<provider>/`
+   - Workflow engine and DSL: `internal/workflows/`, `sdk/workflows/`, `examples/workflows/`
+   - Public examples/docs: `examples/`, `docs/`
+   - Heavy integration coverage: nested `test/` module
+3. Check `.github/workflows/test-and-build.yml` so your verification plan matches CI instead of a guessed workflow.
+4. Decide whether the task touches a high-risk surface: auth, sessions, provider authorization/revocation, Temporal wiring, config/env loading, updater/service install, or public API/CLI behavior.
+5. Write down the smallest set of packages, docs, and tests that should move together before you edit anything.
+
+## Completion Criteria
+
+- You can name the likely owning package(s).
+- You can name the expected docs/examples/config files, if any.
+- You can hand off to the `verify-change`, `provider-or-workflow-change`, `public-surface-change`, or `risky-access-change-review` skill as appropriate.

--- a/.agent-shared/skills/risky-access-change-review.md
+++ b/.agent-shared/skills/risky-access-change-review.md
@@ -1,6 +1,7 @@
 # Risky Access Change Review
 
-Use this skill when reviewing or implementing changes that affect security-sensitive paths in this repo.
+Use this skill when reviewing or implementing changes that affect security-sensitive paths in this
+repo.
 
 ## Required Inputs
 
@@ -17,12 +18,24 @@ Use this skill when reviewing or implementing changes that affect security-sensi
    - Temporal workers, retries, or activity boundaries
    - updater/service install flows
    - config/env loading, secrets, or audit/logging
-2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants access cleanly but leaves revocation, retry, or partial-failure behavior unclear.
-3. Check for least-privilege regressions, broadened defaults, or missing validation around role/resource selection.
-4. Confirm audit/logging still captures the action without leaking credentials, tokens, private keys, or sensitive provider responses.
-5. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
-6. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing, provider/workflow/role changes, and documentation follow-through.
-7. Run the smallest verification set that exercises both success and failure semantics, or call out what could not be validated.
+2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants
+   access cleanly but leaves revocation, retry, or partial-failure behavior unclear. For Temporal
+   changes, also check replay safety, versioning or patching strategy, and whether worker crashes
+   or retries can duplicate external effects; use `temporal-development` for the detailed review
+   checklist.
+3. Reject Temporal anti-patterns in security-sensitive paths, especially workflow-side I/O, unsafe
+   retries around external effects, and incompatible workflow changes without versioning. Use
+   `temporal-development` for the full workflow, activity, handler, and replay-safety guardrails.
+4. Check for least-privilege regressions, broadened defaults, or missing validation around
+   role/resource selection.
+5. Confirm audit/logging still captures the action without leaking credentials, tokens, private
+   keys, or sensitive provider responses.
+6. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
+7. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing,
+   provider, workflow, and role changes, and documentation follow-through.
+8. Run the smallest verification set that exercises both success and failure semantics, or call out
+   what could not be validated. For Go Workflow changes, prefer replay testing and `workflowcheck`
+   per `temporal-development` instead of relying only on happy-path unit tests.
 
 ## Completion Criteria
 

--- a/.agent-shared/skills/risky-access-change-review.md
+++ b/.agent-shared/skills/risky-access-change-review.md
@@ -1,0 +1,31 @@
+# Risky Access Change Review
+
+Use this skill when reviewing or implementing changes that affect security-sensitive paths in this repo.
+
+## Required Inputs
+
+- The diff or change summary
+- Impacted files or packages
+- Any known threat model, incident context, or regression concern
+
+## Steps
+
+1. Check whether the change touches any high-risk surface:
+   - auth/login/session state
+   - provider grant/revoke behavior
+   - role/workflow resolution
+   - Temporal workers, retries, or activity boundaries
+   - updater/service install flows
+   - config/env loading, secrets, or audit/logging
+2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants access cleanly but leaves revocation, retry, or partial-failure behavior unclear.
+3. Check for least-privilege regressions, broadened defaults, or missing validation around role/resource selection.
+4. Confirm audit/logging still captures the action without leaking credentials, tokens, private keys, or sensitive provider responses.
+5. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
+6. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing, provider/workflow/role changes, and documentation follow-through.
+7. Run the smallest verification set that exercises both success and failure semantics, or call out what could not be validated.
+
+## Completion Criteria
+
+- Security impact is explicitly stated.
+- Grant/revoke or enable/disable behavior has been reviewed as a pair.
+- Remaining risks, skipped checks, or external dependencies are called out plainly.

--- a/.agent-shared/skills/temporal-development.md
+++ b/.agent-shared/skills/temporal-development.md
@@ -1,0 +1,108 @@
+# Temporal Development
+
+Use this skill when changing Temporal Workflow Definitions, Activities, local activities, workers,
+message handlers, retries, versioning, or replay-sensitive verification in this repo's Go code.
+
+## Required Inputs
+
+- Changed workflow, activity, worker, or config paths
+- Whether the change touches Workflow Definitions, Activities, local activities, Signals, Queries,
+  Updates, `Continue-As-New`, Search Attributes, or worker registration
+- Whether the change may replay on live executions or only affect new runs
+- Whether `workflowcheck`, representative histories, and the relevant Temporal test environment are
+  available
+
+## Steps
+
+1. Identify the owning workflow surface and registration path before editing:
+   - `internal/workflows/`
+   - `internal/config/workflows.go`
+   - `internal/config/temporal*.go`
+   - `sdk/workflows/`
+   - the affected task queue, worker registration, and Activity registration
+2. Keep Workflow Definitions deterministic:
+   - For the same Event History, workflow code must emit the same Commands in the same order when
+     it replays.
+   - Do not branch on wall-clock time, randomness, process-local state, env var reads, network
+     results, or unordered map iteration in workflow code.
+   - In Go workflow code, use replay-safe Temporal APIs such as `workflow.Go`,
+     `workflow.Channel`, `workflow.Selector`, `workflow.Now`, `workflow.Sleep`, and
+     `workflow.GetLogger` instead of native goroutines, channels, `select`, `time.Now`,
+     `time.Sleep`, or standard blocking primitives.
+3. Keep side effects out of workflow code:
+   - Do not perform direct network, filesystem, database, subprocess, or provider SDK I/O in
+     Workflow Definitions.
+   - Put external I/O, mutable side effects, and fallible business logic in Activities.
+   - Do not hide side effects behind helper functions called from workflow code.
+4. Design Activities for retries:
+   - Make Activities idempotent when they can retry. Use idempotency keys or duplicate detection
+     when the external system supports them.
+   - If an Activity cannot be retried safely, make that explicit in retry policy or error
+     handling.
+   - Split multi-step side effects at retry-safe boundaries so retries do not repeat completed
+     external effects blindly.
+   - For long-running work, heartbeat and persist enough progress or checkpoint detail to resume or
+     fail cleanly.
+5. Use local activities sparingly and with the same retry-safety discipline:
+   - Keep them short, low-latency, and free of long blocking calls.
+   - Treat them as worker-local helpers, not a place to hide slow or durable external
+     orchestration.
+   - In Go, prefer stable named functions over anonymous local-activity functions when that keeps
+     registration, histories, and diagnostics clearer.
+6. Use `SideEffect` and `MutableSideEffect` only for replay-safe value capture:
+   - The callback should return a value and must not mutate Workflow state.
+   - Do not put business logic, blocking work, or external I/O there.
+   - Prefer Activities when the value comes from outside the workflow process.
+7. Keep message handlers safe:
+   - Query handlers are read-only and must not mutate state or run async work.
+   - Signal and Update handlers should stay lightweight, coordinate with main-workflow state, and
+     avoid starting work the main workflow cannot account for safely.
+   - Do not call `Continue-As-New` from Signal or Update handlers.
+   - Before completion or `Continue-As-New`, finish critical in-flight handlers and drain or
+     account for pending Signals. Use `workflow.AllHandlersFinished` when handler completion
+     is part of the workflow's safety boundary.
+   - Prefer serializable request and response structs for handler inputs so interfaces can evolve
+     additively.
+8. Manage history and long-running executions deliberately:
+   - Watch Event History growth for loops, polling patterns, and message-heavy workflows.
+   - Use `Continue-As-New` before history becomes operationally risky.
+   - Carry forward enough workflow state in the next run input to resume safely.
+9. Treat workflow code changes as compatibility-sensitive:
+   - Reordering, adding, or removing command-producing calls for live executions needs Worker
+     Versioning or patching.
+   - This includes timers, Activities, local activities, Child Workflows, external signals,
+     `SideEffect` or `MutableSideEffect`, Search Attribute or Memo upserts, and
+     `Continue-As-New`.
+   - Prefer Worker Versioning for incompatible changes. Use patching when you must bridge old and
+     new histories in code.
+   - Plan rollout around running executions, not just fresh starts.
+10. Verify Temporal changes with replay in mind:
+   - Add or update the nearest unit or integration tests for the changed workflow or activity
+     surface.
+   - For Go Workflow Definition or message-handler changes, run `workflowcheck` when available
+     through repo-local or ephemeral tooling.
+   - Run replay tests against representative histories when practical, especially before shipping
+     changes that may replay on existing executions.
+   - If verification or rollout safety depends on external Temporal state you could not inspect,
+     say so plainly.
+
+## Anti-Patterns To Reject
+
+- direct I/O or side effects in Workflow Definitions
+- native Go goroutines, channels, `select`, `time.Now`, `time.Sleep`, or unordered map iteration
+  in workflow code
+- workflow branches on process-local or wall-clock state that is not recorded in history
+- mutating Workflow state inside `SideEffect` or `MutableSideEffect`
+- non-idempotent Activities that may grant, revoke, provision, charge, or notify twice on retry
+- long or unreliable work hidden in local activities
+- `Continue-As-New` or completion while important Signal or Update handler work is still in flight
+- incompatible command-sequence changes without Worker Versioning or patching
+- shipping workflow-definition changes based only on happy-path unit tests when replay validation
+  is feasible
+
+## Completion Criteria
+
+- Workflow code remains deterministic and side-effect free.
+- Activity boundaries and retry policy are explicit and safe for the external systems involved.
+- Message-handler, `Continue-As-New`, and versioning behavior are reviewed when applicable.
+- Replay-oriented verification and rollout risks are documented, run, or explicitly deferred.

--- a/.agent-shared/skills/verify-change.md
+++ b/.agent-shared/skills/verify-change.md
@@ -1,6 +1,7 @@
 # Verify Change
 
-Use this skill after making a change, or earlier when you need to choose the right verification scope for the affected subsystem.
+Use this skill after making a change, or earlier when you need to choose the right verification
+scope for the affected subsystem.
 
 ## Required Inputs
 
@@ -10,20 +11,31 @@ Use this skill after making a change, or earlier when you need to choose the rig
 
 ## Steps
 
-1. Run `gofmt -w` on every changed Go file.
-2. Run root-module tests for code in the main module. Start with the narrowest useful package tests; use `go test ./...` when the change crosses packages or you need broader confidence.
-3. If the change affects behavior covered by the nested `test/` module, run the matching suite:
+1. Prefer TDD-style verification when practical: add or update a failing test first, confirm it
+   fails on the pre-change behavior, then implement the fix and rerun the targeted tests to confirm
+   they pass.
+2. Run `gofmt -w` on every changed Go file.
+3. Run root-module tests for code in the main module. Start with the narrowest useful package
+   tests; use `go test ./...` when the change crosses packages or you need broader confidence.
+4. If the change affects behavior covered by the nested `test/` module, run the matching suite:
    - Functional provider behavior: `cd test && go test -v -timeout 10m ./functional/...`
    - Services/Temporal wiring: `cd test && go test -v -timeout 5m ./integration/services/...`
    - Workflow behavior: `cd test && go test -v -timeout 15m ./integration/workflows/...`
-   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
-4. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll build`.
-5. If the change affects API annotations or generated Swagger assets, run `make swagger`.
-6. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
-7. Record every command you ran and call out anything you intentionally skipped.
+   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m
+     ./integration/frontend/...`
+5. If the change touches Go Workflow Definitions or message handlers, use
+   `temporal-development` to scope determinism checks, including replay testing and
+   `workflowcheck` when practical.
+6. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll
+   build`.
+7. If the change affects API annotations or generated Swagger assets, run `make swagger`.
+8. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
+9. Record every command you ran and call out anything you intentionally skipped.
 
 ## Completion Criteria
 
 - Changed Go files are formatted.
 - Relevant tests/builds have been run, or skipped with a concrete reason.
+- Temporal determinism checks from `temporal-development` were included for Workflow-definition
+  changes, or explicitly deferred.
 - Any required generated artifacts have been refreshed.

--- a/.agent-shared/skills/verify-change.md
+++ b/.agent-shared/skills/verify-change.md
@@ -1,0 +1,29 @@
+# Verify Change
+
+Use this skill after making a change, or earlier when you need to choose the right verification scope for the affected subsystem.
+
+## Required Inputs
+
+- Changed paths or packages
+- Whether Docker, Chromium, Ruby/Bundler, `swag`, and `flatc` are available
+- Whether the change is internal-only or user-facing
+
+## Steps
+
+1. Run `gofmt -w` on every changed Go file.
+2. Run root-module tests for code in the main module. Start with the narrowest useful package tests; use `go test ./...` when the change crosses packages or you need broader confidence.
+3. If the change affects behavior covered by the nested `test/` module, run the matching suite:
+   - Functional provider behavior: `cd test && go test -v -timeout 10m ./functional/...`
+   - Services/Temporal wiring: `cd test && go test -v -timeout 5m ./integration/services/...`
+   - Workflow behavior: `cd test && go test -v -timeout 15m ./integration/workflows/...`
+   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
+4. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll build`.
+5. If the change affects API annotations or generated Swagger assets, run `make swagger`.
+6. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
+7. Record every command you ran and call out anything you intentionally skipped.
+
+## Completion Criteria
+
+- Changed Go files are formatted.
+- Relevant tests/builds have been run, or skipped with a concrete reason.
+- Any required generated artifacts have been refreshed.

--- a/.agents/skills/provider-or-workflow-change/SKILL.md
+++ b/.agents/skills/provider-or-workflow-change/SKILL.md
@@ -1,0 +1,34 @@
+> Generated from `.agent-shared/skills/provider-or-workflow-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Provider Or Workflow Change
+
+Use this skill when changing provider integrations, role resolution, workflow definitions, or the wiring that connects those pieces.
+
+## Required Inputs
+
+- Provider name, role name, or workflow name
+- Intended behavior change
+- Whether the change affects authorization, revocation, session handling, or examples/docs
+
+## Steps
+
+1. Identify the owning package and follow the existing pattern before adding new files:
+   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`, RBAC/auth/session helpers, and tests.
+   - Workflow-related behavior is usually wired through `internal/workflows/`, `internal/config/workflows.go`, and `internal/config/temporal*.go`.
+2. Trace registration and config loading, not just the leaf implementation:
+   - `internal/providers/registry.go`
+   - `internal/config/providers.go`
+   - `internal/config/roles.go`
+   - `internal/config/workflows.go`
+   - `config.example.yaml`, `examples/providers/`, `examples/roles/`, `examples/workflows/`
+3. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal activity boundaries.
+4. Add or update tests in the nearest package, then choose the matching nested `test/` suite if runtime behavior changed.
+5. Update docs/examples whenever a user would need to configure or invoke the new behavior differently.
+6. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md` and `sdk/workflows/` before finalizing.
+
+## Completion Criteria
+
+- Registration, config, examples, and docs are consistent with the implementation.
+- Grant/revoke or start/stop behavior is covered, not just creation.
+- Appropriate package and integration tests are updated or explicitly deferred.
+

--- a/.agents/skills/provider-or-workflow-change/SKILL.md
+++ b/.agents/skills/provider-or-workflow-change/SKILL.md
@@ -1,8 +1,11 @@
-> Generated from `.agent-shared/skills/provider-or-workflow-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/provider-or-workflow-change.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Provider Or Workflow Change
 
-Use this skill when changing provider integrations, role resolution, workflow definitions, or the wiring that connects those pieces.
+Use this skill when changing provider integrations, role resolution, workflow definitions, or the
+wiring that connects those pieces.
 
 ## Required Inputs
 
@@ -13,18 +16,28 @@ Use this skill when changing provider integrations, role resolution, workflow de
 ## Steps
 
 1. Identify the owning package and follow the existing pattern before adding new files:
-   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`, RBAC/auth/session helpers, and tests.
-   - Workflow-related behavior is usually wired through `internal/workflows/`, `internal/config/workflows.go`, and `internal/config/temporal*.go`.
+   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`,
+     RBAC/auth/session helpers, and tests.
+   - Workflow-related behavior is usually wired through `internal/workflows/`,
+     `internal/config/workflows.go`, and `internal/config/temporal*.go`.
 2. Trace registration and config loading, not just the leaf implementation:
    - `internal/providers/registry.go`
    - `internal/config/providers.go`
    - `internal/config/roles.go`
    - `internal/config/workflows.go`
    - `config.example.yaml`, `examples/providers/`, `examples/roles/`, `examples/workflows/`
-3. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal activity boundaries.
-4. Add or update tests in the nearest package, then choose the matching nested `test/` suite if runtime behavior changed.
-5. Update docs/examples whenever a user would need to configure or invoke the new behavior differently.
-6. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md` and `sdk/workflows/` before finalizing.
+3. If the change touches Temporal Workflow Definitions, Activities, local activities, message
+   handlers, retries, or versioning, use the `temporal-development` skill for the detailed
+   determinism, handler-safety, and compatibility checklist.
+4. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal
+   activity boundaries.
+5. Add or update tests in the nearest package, then choose the matching nested `test/` suite if
+   runtime behavior changed. For Go Workflow Definition changes, include replay testing and
+   `workflowcheck` per `temporal-development` when practical.
+6. Update docs/examples whenever a user would need to configure or invoke the new behavior
+   differently.
+7. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md`
+   and `sdk/workflows/` before finalizing.
 
 ## Completion Criteria
 

--- a/.agents/skills/public-surface-change/SKILL.md
+++ b/.agents/skills/public-surface-change/SKILL.md
@@ -1,0 +1,30 @@
+> Generated from `.agent-shared/skills/public-surface-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Public Surface Change
+
+Use this skill when a change alters user-facing CLI behavior, HTTP/API behavior, config shape, examples, docs, or release/build semantics.
+
+## Required Inputs
+
+- The user-facing surface that changed
+- The implementation files that drove the change
+
+## Steps
+
+1. Identify the public surface:
+   - CLI: `cmd/cli/`, `cmd/cli/README.md`, `README.md`, `docs/configuration/cli.md`
+   - API/server: `internal/daemon/`, `internal/api/`, `docs/api/`, `docs/swagger.json`, `docs/swagger.yaml`, `docs/docs.go`
+   - Config/examples: `config.example.yaml`, `examples/`, `docs/configuration/`
+   - Release/build/docs tooling: `Makefile`, `Dockerfile*`, `.github/workflows/`, `RELEASE.md`, `docs/`
+2. Update the code and the user-facing description in the same change whenever possible.
+3. If API annotations changed, regenerate Swagger assets with `make swagger`.
+4. If config keys, workflow examples, or provider examples changed, update `config.example.yaml`, the matching `examples/` file, and the relevant docs page together.
+5. If docs-site content changed, run `cd docs && bundle exec jekyll build`.
+6. If release or CI semantics changed, verify the impacted workflow file and `RELEASE.md` stay aligned.
+
+## Completion Criteria
+
+- Code and user-facing docs/examples/config describe the same behavior.
+- Generated docs artifacts are refreshed when needed.
+- Verification covers both the implementation and the public surface.
+

--- a/.agents/skills/public-surface-change/SKILL.md
+++ b/.agents/skills/public-surface-change/SKILL.md
@@ -1,4 +1,6 @@
-> Generated from `.agent-shared/skills/public-surface-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/public-surface-change.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Public Surface Change
 

--- a/.agents/skills/repo-orientation/SKILL.md
+++ b/.agents/skills/repo-orientation/SKILL.md
@@ -1,0 +1,32 @@
+> Generated from `.agent-shared/skills/repo-orientation.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Repo Orientation
+
+Use this skill when you are entering the repo for a new task, the request spans multiple packages, or you need to map a change to the owning subsystem before editing.
+
+## Required Inputs
+
+- The task statement
+- Any known file paths or package names
+
+## Steps
+
+1. Read `README.md`, `Makefile`, and `config.example.yaml`.
+2. Map the request to the main surfaces:
+   - CLI and startup flow: `main.go`, `cmd/cli/`
+   - Server/API: `internal/daemon/`, `internal/api/`
+   - Config/bootstrap: `internal/config/`
+   - Providers and RBAC: `internal/providers/<provider>/`
+   - Workflow engine and DSL: `internal/workflows/`, `sdk/workflows/`, `examples/workflows/`
+   - Public examples/docs: `examples/`, `docs/`
+   - Heavy integration coverage: nested `test/` module
+3. Check `.github/workflows/test-and-build.yml` so your verification plan matches CI instead of a guessed workflow.
+4. Decide whether the task touches a high-risk surface: auth, sessions, provider authorization/revocation, Temporal wiring, config/env loading, updater/service install, or public API/CLI behavior.
+5. Write down the smallest set of packages, docs, and tests that should move together before you edit anything.
+
+## Completion Criteria
+
+- You can name the likely owning package(s).
+- You can name the expected docs/examples/config files, if any.
+- You can hand off to the `verify-change`, `provider-or-workflow-change`, `public-surface-change`, or `risky-access-change-review` skill as appropriate.
+

--- a/.agents/skills/repo-orientation/SKILL.md
+++ b/.agents/skills/repo-orientation/SKILL.md
@@ -1,4 +1,6 @@
-> Generated from `.agent-shared/skills/repo-orientation.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/repo-orientation.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Repo Orientation
 

--- a/.agents/skills/risky-access-change-review/SKILL.md
+++ b/.agents/skills/risky-access-change-review/SKILL.md
@@ -1,8 +1,11 @@
-> Generated from `.agent-shared/skills/risky-access-change-review.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/risky-access-change-review.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Risky Access Change Review
 
-Use this skill when reviewing or implementing changes that affect security-sensitive paths in this repo.
+Use this skill when reviewing or implementing changes that affect security-sensitive paths in this
+repo.
 
 ## Required Inputs
 
@@ -19,12 +22,24 @@ Use this skill when reviewing or implementing changes that affect security-sensi
    - Temporal workers, retries, or activity boundaries
    - updater/service install flows
    - config/env loading, secrets, or audit/logging
-2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants access cleanly but leaves revocation, retry, or partial-failure behavior unclear.
-3. Check for least-privilege regressions, broadened defaults, or missing validation around role/resource selection.
-4. Confirm audit/logging still captures the action without leaking credentials, tokens, private keys, or sensitive provider responses.
-5. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
-6. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing, provider/workflow/role changes, and documentation follow-through.
-7. Run the smallest verification set that exercises both success and failure semantics, or call out what could not be validated.
+2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants
+   access cleanly but leaves revocation, retry, or partial-failure behavior unclear. For Temporal
+   changes, also check replay safety, versioning or patching strategy, and whether worker crashes
+   or retries can duplicate external effects; use `temporal-development` for the detailed review
+   checklist.
+3. Reject Temporal anti-patterns in security-sensitive paths, especially workflow-side I/O, unsafe
+   retries around external effects, and incompatible workflow changes without versioning. Use
+   `temporal-development` for the full workflow, activity, handler, and replay-safety guardrails.
+4. Check for least-privilege regressions, broadened defaults, or missing validation around
+   role/resource selection.
+5. Confirm audit/logging still captures the action without leaking credentials, tokens, private
+   keys, or sensitive provider responses.
+6. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
+7. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing,
+   provider, workflow, and role changes, and documentation follow-through.
+8. Run the smallest verification set that exercises both success and failure semantics, or call out
+   what could not be validated. For Go Workflow changes, prefer replay testing and `workflowcheck`
+   per `temporal-development` instead of relying only on happy-path unit tests.
 
 ## Completion Criteria
 

--- a/.agents/skills/risky-access-change-review/SKILL.md
+++ b/.agents/skills/risky-access-change-review/SKILL.md
@@ -1,0 +1,34 @@
+> Generated from `.agent-shared/skills/risky-access-change-review.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Risky Access Change Review
+
+Use this skill when reviewing or implementing changes that affect security-sensitive paths in this repo.
+
+## Required Inputs
+
+- The diff or change summary
+- Impacted files or packages
+- Any known threat model, incident context, or regression concern
+
+## Steps
+
+1. Check whether the change touches any high-risk surface:
+   - auth/login/session state
+   - provider grant/revoke behavior
+   - role/workflow resolution
+   - Temporal workers, retries, or activity boundaries
+   - updater/service install flows
+   - config/env loading, secrets, or audit/logging
+2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants access cleanly but leaves revocation, retry, or partial-failure behavior unclear.
+3. Check for least-privilege regressions, broadened defaults, or missing validation around role/resource selection.
+4. Confirm audit/logging still captures the action without leaking credentials, tokens, private keys, or sensitive provider responses.
+5. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
+6. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing, provider/workflow/role changes, and documentation follow-through.
+7. Run the smallest verification set that exercises both success and failure semantics, or call out what could not be validated.
+
+## Completion Criteria
+
+- Security impact is explicitly stated.
+- Grant/revoke or enable/disable behavior has been reviewed as a pair.
+- Remaining risks, skipped checks, or external dependencies are called out plainly.
+

--- a/.agents/skills/temporal-development/SKILL.md
+++ b/.agents/skills/temporal-development/SKILL.md
@@ -1,0 +1,113 @@
+> Generated from:
+> `.agent-shared/skills/temporal-development.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Temporal Development
+
+Use this skill when changing Temporal Workflow Definitions, Activities, local activities, workers,
+message handlers, retries, versioning, or replay-sensitive verification in this repo's Go code.
+
+## Required Inputs
+
+- Changed workflow, activity, worker, or config paths
+- Whether the change touches Workflow Definitions, Activities, local activities, Signals, Queries,
+  Updates, `Continue-As-New`, Search Attributes, or worker registration
+- Whether the change may replay on live executions or only affect new runs
+- Whether `workflowcheck`, representative histories, and the relevant Temporal test environment are
+  available
+
+## Steps
+
+1. Identify the owning workflow surface and registration path before editing:
+   - `internal/workflows/`
+   - `internal/config/workflows.go`
+   - `internal/config/temporal*.go`
+   - `sdk/workflows/`
+   - the affected task queue, worker registration, and Activity registration
+2. Keep Workflow Definitions deterministic:
+   - For the same Event History, workflow code must emit the same Commands in the same order when
+     it replays.
+   - Do not branch on wall-clock time, randomness, process-local state, env var reads, network
+     results, or unordered map iteration in workflow code.
+   - In Go workflow code, use replay-safe Temporal APIs such as `workflow.Go`,
+     `workflow.Channel`, `workflow.Selector`, `workflow.Now`, `workflow.Sleep`, and
+     `workflow.GetLogger` instead of native goroutines, channels, `select`, `time.Now`,
+     `time.Sleep`, or standard blocking primitives.
+3. Keep side effects out of workflow code:
+   - Do not perform direct network, filesystem, database, subprocess, or provider SDK I/O in
+     Workflow Definitions.
+   - Put external I/O, mutable side effects, and fallible business logic in Activities.
+   - Do not hide side effects behind helper functions called from workflow code.
+4. Design Activities for retries:
+   - Make Activities idempotent when they can retry. Use idempotency keys or duplicate detection
+     when the external system supports them.
+   - If an Activity cannot be retried safely, make that explicit in retry policy or error
+     handling.
+   - Split multi-step side effects at retry-safe boundaries so retries do not repeat completed
+     external effects blindly.
+   - For long-running work, heartbeat and persist enough progress or checkpoint detail to resume or
+     fail cleanly.
+5. Use local activities sparingly and with the same retry-safety discipline:
+   - Keep them short, low-latency, and free of long blocking calls.
+   - Treat them as worker-local helpers, not a place to hide slow or durable external
+     orchestration.
+   - In Go, prefer stable named functions over anonymous local-activity functions when that keeps
+     registration, histories, and diagnostics clearer.
+6. Use `SideEffect` and `MutableSideEffect` only for replay-safe value capture:
+   - The callback should return a value and must not mutate Workflow state.
+   - Do not put business logic, blocking work, or external I/O there.
+   - Prefer Activities when the value comes from outside the workflow process.
+7. Keep message handlers safe:
+   - Query handlers are read-only and must not mutate state or run async work.
+   - Signal and Update handlers should stay lightweight, coordinate with main-workflow state, and
+     avoid starting work the main workflow cannot account for safely.
+   - Do not call `Continue-As-New` from Signal or Update handlers.
+   - Before completion or `Continue-As-New`, finish critical in-flight handlers and drain or
+     account for pending Signals. Use `workflow.AllHandlersFinished` when handler completion
+     is part of the workflow's safety boundary.
+   - Prefer serializable request and response structs for handler inputs so interfaces can evolve
+     additively.
+8. Manage history and long-running executions deliberately:
+   - Watch Event History growth for loops, polling patterns, and message-heavy workflows.
+   - Use `Continue-As-New` before history becomes operationally risky.
+   - Carry forward enough workflow state in the next run input to resume safely.
+9. Treat workflow code changes as compatibility-sensitive:
+   - Reordering, adding, or removing command-producing calls for live executions needs Worker
+     Versioning or patching.
+   - This includes timers, Activities, local activities, Child Workflows, external signals,
+     `SideEffect` or `MutableSideEffect`, Search Attribute or Memo upserts, and
+     `Continue-As-New`.
+   - Prefer Worker Versioning for incompatible changes. Use patching when you must bridge old and
+     new histories in code.
+   - Plan rollout around running executions, not just fresh starts.
+10. Verify Temporal changes with replay in mind:
+   - Add or update the nearest unit or integration tests for the changed workflow or activity
+     surface.
+   - For Go Workflow Definition or message-handler changes, run `workflowcheck` when available
+     through repo-local or ephemeral tooling.
+   - Run replay tests against representative histories when practical, especially before shipping
+     changes that may replay on existing executions.
+   - If verification or rollout safety depends on external Temporal state you could not inspect,
+     say so plainly.
+
+## Anti-Patterns To Reject
+
+- direct I/O or side effects in Workflow Definitions
+- native Go goroutines, channels, `select`, `time.Now`, `time.Sleep`, or unordered map iteration
+  in workflow code
+- workflow branches on process-local or wall-clock state that is not recorded in history
+- mutating Workflow state inside `SideEffect` or `MutableSideEffect`
+- non-idempotent Activities that may grant, revoke, provision, charge, or notify twice on retry
+- long or unreliable work hidden in local activities
+- `Continue-As-New` or completion while important Signal or Update handler work is still in flight
+- incompatible command-sequence changes without Worker Versioning or patching
+- shipping workflow-definition changes based only on happy-path unit tests when replay validation
+  is feasible
+
+## Completion Criteria
+
+- Workflow code remains deterministic and side-effect free.
+- Activity boundaries and retry policy are explicit and safe for the external systems involved.
+- Message-handler, `Continue-As-New`, and versioning behavior are reviewed when applicable.
+- Replay-oriented verification and rollout risks are documented, run, or explicitly deferred.
+

--- a/.agents/skills/verify-change/SKILL.md
+++ b/.agents/skills/verify-change/SKILL.md
@@ -1,0 +1,32 @@
+> Generated from `.agent-shared/skills/verify-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Verify Change
+
+Use this skill after making a change, or earlier when you need to choose the right verification scope for the affected subsystem.
+
+## Required Inputs
+
+- Changed paths or packages
+- Whether Docker, Chromium, Ruby/Bundler, `swag`, and `flatc` are available
+- Whether the change is internal-only or user-facing
+
+## Steps
+
+1. Run `gofmt -w` on every changed Go file.
+2. Run root-module tests for code in the main module. Start with the narrowest useful package tests; use `go test ./...` when the change crosses packages or you need broader confidence.
+3. If the change affects behavior covered by the nested `test/` module, run the matching suite:
+   - Functional provider behavior: `cd test && go test -v -timeout 10m ./functional/...`
+   - Services/Temporal wiring: `cd test && go test -v -timeout 5m ./integration/services/...`
+   - Workflow behavior: `cd test && go test -v -timeout 15m ./integration/workflows/...`
+   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
+4. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll build`.
+5. If the change affects API annotations or generated Swagger assets, run `make swagger`.
+6. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
+7. Record every command you ran and call out anything you intentionally skipped.
+
+## Completion Criteria
+
+- Changed Go files are formatted.
+- Relevant tests/builds have been run, or skipped with a concrete reason.
+- Any required generated artifacts have been refreshed.
+

--- a/.agents/skills/verify-change/SKILL.md
+++ b/.agents/skills/verify-change/SKILL.md
@@ -1,8 +1,11 @@
-> Generated from `.agent-shared/skills/verify-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/verify-change.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Verify Change
 
-Use this skill after making a change, or earlier when you need to choose the right verification scope for the affected subsystem.
+Use this skill after making a change, or earlier when you need to choose the right verification
+scope for the affected subsystem.
 
 ## Required Inputs
 
@@ -12,21 +15,32 @@ Use this skill after making a change, or earlier when you need to choose the rig
 
 ## Steps
 
-1. Run `gofmt -w` on every changed Go file.
-2. Run root-module tests for code in the main module. Start with the narrowest useful package tests; use `go test ./...` when the change crosses packages or you need broader confidence.
-3. If the change affects behavior covered by the nested `test/` module, run the matching suite:
+1. Prefer TDD-style verification when practical: add or update a failing test first, confirm it
+   fails on the pre-change behavior, then implement the fix and rerun the targeted tests to confirm
+   they pass.
+2. Run `gofmt -w` on every changed Go file.
+3. Run root-module tests for code in the main module. Start with the narrowest useful package
+   tests; use `go test ./...` when the change crosses packages or you need broader confidence.
+4. If the change affects behavior covered by the nested `test/` module, run the matching suite:
    - Functional provider behavior: `cd test && go test -v -timeout 10m ./functional/...`
    - Services/Temporal wiring: `cd test && go test -v -timeout 5m ./integration/services/...`
    - Workflow behavior: `cd test && go test -v -timeout 15m ./integration/workflows/...`
-   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
-4. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll build`.
-5. If the change affects API annotations or generated Swagger assets, run `make swagger`.
-6. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
-7. Record every command you ran and call out anything you intentionally skipped.
+   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m
+     ./integration/frontend/...`
+5. If the change touches Go Workflow Definitions or message handlers, use
+   `temporal-development` to scope determinism checks, including replay testing and
+   `workflowcheck` when practical.
+6. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll
+   build`.
+7. If the change affects API annotations or generated Swagger assets, run `make swagger`.
+8. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
+9. Record every command you ran and call out anything you intentionally skipped.
 
 ## Completion Criteria
 
 - Changed Go files are formatted.
 - Relevant tests/builds have been run, or skipped with a concrete reason.
+- Temporal determinism checks from `temporal-development` were included for Workflow-definition
+  changes, or explicitly deferred.
 - Any required generated artifacts have been refreshed.
 

--- a/.claude/skills/provider-or-workflow-change.md
+++ b/.claude/skills/provider-or-workflow-change.md
@@ -1,0 +1,34 @@
+> Generated from `.agent-shared/skills/provider-or-workflow-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Provider Or Workflow Change
+
+Use this skill when changing provider integrations, role resolution, workflow definitions, or the wiring that connects those pieces.
+
+## Required Inputs
+
+- Provider name, role name, or workflow name
+- Intended behavior change
+- Whether the change affects authorization, revocation, session handling, or examples/docs
+
+## Steps
+
+1. Identify the owning package and follow the existing pattern before adding new files:
+   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`, RBAC/auth/session helpers, and tests.
+   - Workflow-related behavior is usually wired through `internal/workflows/`, `internal/config/workflows.go`, and `internal/config/temporal*.go`.
+2. Trace registration and config loading, not just the leaf implementation:
+   - `internal/providers/registry.go`
+   - `internal/config/providers.go`
+   - `internal/config/roles.go`
+   - `internal/config/workflows.go`
+   - `config.example.yaml`, `examples/providers/`, `examples/roles/`, `examples/workflows/`
+3. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal activity boundaries.
+4. Add or update tests in the nearest package, then choose the matching nested `test/` suite if runtime behavior changed.
+5. Update docs/examples whenever a user would need to configure or invoke the new behavior differently.
+6. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md` and `sdk/workflows/` before finalizing.
+
+## Completion Criteria
+
+- Registration, config, examples, and docs are consistent with the implementation.
+- Grant/revoke or start/stop behavior is covered, not just creation.
+- Appropriate package and integration tests are updated or explicitly deferred.
+

--- a/.claude/skills/provider-or-workflow-change.md
+++ b/.claude/skills/provider-or-workflow-change.md
@@ -1,8 +1,11 @@
-> Generated from `.agent-shared/skills/provider-or-workflow-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/provider-or-workflow-change.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Provider Or Workflow Change
 
-Use this skill when changing provider integrations, role resolution, workflow definitions, or the wiring that connects those pieces.
+Use this skill when changing provider integrations, role resolution, workflow definitions, or the
+wiring that connects those pieces.
 
 ## Required Inputs
 
@@ -13,18 +16,28 @@ Use this skill when changing provider integrations, role resolution, workflow de
 ## Steps
 
 1. Identify the owning package and follow the existing pattern before adding new files:
-   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`, RBAC/auth/session helpers, and tests.
-   - Workflow-related behavior is usually wired through `internal/workflows/`, `internal/config/workflows.go`, and `internal/config/temporal*.go`.
+   - Provider packages usually split logic across `main.go`, `capabilities.go`, `schema.go`,
+     RBAC/auth/session helpers, and tests.
+   - Workflow-related behavior is usually wired through `internal/workflows/`,
+     `internal/config/workflows.go`, and `internal/config/temporal*.go`.
 2. Trace registration and config loading, not just the leaf implementation:
    - `internal/providers/registry.go`
    - `internal/config/providers.go`
    - `internal/config/roles.go`
    - `internal/config/workflows.go`
    - `config.example.yaml`, `examples/providers/`, `examples/roles/`, `examples/workflows/`
-3. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal activity boundaries.
-4. Add or update tests in the nearest package, then choose the matching nested `test/` suite if runtime behavior changed.
-5. Update docs/examples whenever a user would need to configure or invoke the new behavior differently.
-6. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md` and `sdk/workflows/` before finalizing.
+3. If the change touches Temporal Workflow Definitions, Activities, local activities, message
+   handlers, retries, or versioning, use the `temporal-development` skill for the detailed
+   determinism, handler-safety, and compatibility checklist.
+4. Keep grant and revoke behavior symmetric and review idempotency/retry behavior around Temporal
+   activity boundaries.
+5. Add or update tests in the nearest package, then choose the matching nested `test/` suite if
+   runtime behavior changed. For Go Workflow Definition changes, include replay testing and
+   `workflowcheck` per `temporal-development` when practical.
+6. Update docs/examples whenever a user would need to configure or invoke the new behavior
+   differently.
+7. If the task touches the workflow DSL or runtime semantics, inspect `internal/workflows/DSL.md`
+   and `sdk/workflows/` before finalizing.
 
 ## Completion Criteria
 

--- a/.claude/skills/public-surface-change.md
+++ b/.claude/skills/public-surface-change.md
@@ -1,0 +1,30 @@
+> Generated from `.agent-shared/skills/public-surface-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Public Surface Change
+
+Use this skill when a change alters user-facing CLI behavior, HTTP/API behavior, config shape, examples, docs, or release/build semantics.
+
+## Required Inputs
+
+- The user-facing surface that changed
+- The implementation files that drove the change
+
+## Steps
+
+1. Identify the public surface:
+   - CLI: `cmd/cli/`, `cmd/cli/README.md`, `README.md`, `docs/configuration/cli.md`
+   - API/server: `internal/daemon/`, `internal/api/`, `docs/api/`, `docs/swagger.json`, `docs/swagger.yaml`, `docs/docs.go`
+   - Config/examples: `config.example.yaml`, `examples/`, `docs/configuration/`
+   - Release/build/docs tooling: `Makefile`, `Dockerfile*`, `.github/workflows/`, `RELEASE.md`, `docs/`
+2. Update the code and the user-facing description in the same change whenever possible.
+3. If API annotations changed, regenerate Swagger assets with `make swagger`.
+4. If config keys, workflow examples, or provider examples changed, update `config.example.yaml`, the matching `examples/` file, and the relevant docs page together.
+5. If docs-site content changed, run `cd docs && bundle exec jekyll build`.
+6. If release or CI semantics changed, verify the impacted workflow file and `RELEASE.md` stay aligned.
+
+## Completion Criteria
+
+- Code and user-facing docs/examples/config describe the same behavior.
+- Generated docs artifacts are refreshed when needed.
+- Verification covers both the implementation and the public surface.
+

--- a/.claude/skills/public-surface-change.md
+++ b/.claude/skills/public-surface-change.md
@@ -1,4 +1,6 @@
-> Generated from `.agent-shared/skills/public-surface-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/public-surface-change.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Public Surface Change
 

--- a/.claude/skills/repo-orientation.md
+++ b/.claude/skills/repo-orientation.md
@@ -1,0 +1,32 @@
+> Generated from `.agent-shared/skills/repo-orientation.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Repo Orientation
+
+Use this skill when you are entering the repo for a new task, the request spans multiple packages, or you need to map a change to the owning subsystem before editing.
+
+## Required Inputs
+
+- The task statement
+- Any known file paths or package names
+
+## Steps
+
+1. Read `README.md`, `Makefile`, and `config.example.yaml`.
+2. Map the request to the main surfaces:
+   - CLI and startup flow: `main.go`, `cmd/cli/`
+   - Server/API: `internal/daemon/`, `internal/api/`
+   - Config/bootstrap: `internal/config/`
+   - Providers and RBAC: `internal/providers/<provider>/`
+   - Workflow engine and DSL: `internal/workflows/`, `sdk/workflows/`, `examples/workflows/`
+   - Public examples/docs: `examples/`, `docs/`
+   - Heavy integration coverage: nested `test/` module
+3. Check `.github/workflows/test-and-build.yml` so your verification plan matches CI instead of a guessed workflow.
+4. Decide whether the task touches a high-risk surface: auth, sessions, provider authorization/revocation, Temporal wiring, config/env loading, updater/service install, or public API/CLI behavior.
+5. Write down the smallest set of packages, docs, and tests that should move together before you edit anything.
+
+## Completion Criteria
+
+- You can name the likely owning package(s).
+- You can name the expected docs/examples/config files, if any.
+- You can hand off to the `verify-change`, `provider-or-workflow-change`, `public-surface-change`, or `risky-access-change-review` skill as appropriate.
+

--- a/.claude/skills/repo-orientation.md
+++ b/.claude/skills/repo-orientation.md
@@ -1,4 +1,6 @@
-> Generated from `.agent-shared/skills/repo-orientation.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/repo-orientation.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Repo Orientation
 

--- a/.claude/skills/risky-access-change-review.md
+++ b/.claude/skills/risky-access-change-review.md
@@ -1,8 +1,11 @@
-> Generated from `.agent-shared/skills/risky-access-change-review.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/risky-access-change-review.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Risky Access Change Review
 
-Use this skill when reviewing or implementing changes that affect security-sensitive paths in this repo.
+Use this skill when reviewing or implementing changes that affect security-sensitive paths in this
+repo.
 
 ## Required Inputs
 
@@ -19,12 +22,24 @@ Use this skill when reviewing or implementing changes that affect security-sensi
    - Temporal workers, retries, or activity boundaries
    - updater/service install flows
    - config/env loading, secrets, or audit/logging
-2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants access cleanly but leaves revocation, retry, or partial-failure behavior unclear.
-3. Check for least-privilege regressions, broadened defaults, or missing validation around role/resource selection.
-4. Confirm audit/logging still captures the action without leaking credentials, tokens, private keys, or sensitive provider responses.
-5. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
-6. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing, provider/workflow/role changes, and documentation follow-through.
-7. Run the smallest verification set that exercises both success and failure semantics, or call out what could not be validated.
+2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants
+   access cleanly but leaves revocation, retry, or partial-failure behavior unclear. For Temporal
+   changes, also check replay safety, versioning or patching strategy, and whether worker crashes
+   or retries can duplicate external effects; use `temporal-development` for the detailed review
+   checklist.
+3. Reject Temporal anti-patterns in security-sensitive paths, especially workflow-side I/O, unsafe
+   retries around external effects, and incompatible workflow changes without versioning. Use
+   `temporal-development` for the full workflow, activity, handler, and replay-safety guardrails.
+4. Check for least-privilege regressions, broadened defaults, or missing validation around
+   role/resource selection.
+5. Confirm audit/logging still captures the action without leaking credentials, tokens, private
+   keys, or sensitive provider responses.
+6. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
+7. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing,
+   provider, workflow, and role changes, and documentation follow-through.
+8. Run the smallest verification set that exercises both success and failure semantics, or call out
+   what could not be validated. For Go Workflow changes, prefer replay testing and `workflowcheck`
+   per `temporal-development` instead of relying only on happy-path unit tests.
 
 ## Completion Criteria
 

--- a/.claude/skills/risky-access-change-review.md
+++ b/.claude/skills/risky-access-change-review.md
@@ -1,0 +1,34 @@
+> Generated from `.agent-shared/skills/risky-access-change-review.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Risky Access Change Review
+
+Use this skill when reviewing or implementing changes that affect security-sensitive paths in this repo.
+
+## Required Inputs
+
+- The diff or change summary
+- Impacted files or packages
+- Any known threat model, incident context, or regression concern
+
+## Steps
+
+1. Check whether the change touches any high-risk surface:
+   - auth/login/session state
+   - provider grant/revoke behavior
+   - role/workflow resolution
+   - Temporal workers, retries, or activity boundaries
+   - updater/service install flows
+   - config/env loading, secrets, or audit/logging
+2. Review both the happy path and the cleanup/failure path. A change is incomplete if it grants access cleanly but leaves revocation, retry, or partial-failure behavior unclear.
+3. Check for least-privilege regressions, broadened defaults, or missing validation around role/resource selection.
+4. Confirm audit/logging still captures the action without leaking credentials, tokens, private keys, or sensitive provider responses.
+5. Verify docs/examples/tests do not introduce secrets or normalize unsafe defaults.
+6. Use `.github/PULL_REQUEST_TEMPLATE.md` as a concrete checklist for security impact, testing, provider/workflow/role changes, and documentation follow-through.
+7. Run the smallest verification set that exercises both success and failure semantics, or call out what could not be validated.
+
+## Completion Criteria
+
+- Security impact is explicitly stated.
+- Grant/revoke or enable/disable behavior has been reviewed as a pair.
+- Remaining risks, skipped checks, or external dependencies are called out plainly.
+

--- a/.claude/skills/temporal-development.md
+++ b/.claude/skills/temporal-development.md
@@ -1,0 +1,113 @@
+> Generated from:
+> `.agent-shared/skills/temporal-development.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Temporal Development
+
+Use this skill when changing Temporal Workflow Definitions, Activities, local activities, workers,
+message handlers, retries, versioning, or replay-sensitive verification in this repo's Go code.
+
+## Required Inputs
+
+- Changed workflow, activity, worker, or config paths
+- Whether the change touches Workflow Definitions, Activities, local activities, Signals, Queries,
+  Updates, `Continue-As-New`, Search Attributes, or worker registration
+- Whether the change may replay on live executions or only affect new runs
+- Whether `workflowcheck`, representative histories, and the relevant Temporal test environment are
+  available
+
+## Steps
+
+1. Identify the owning workflow surface and registration path before editing:
+   - `internal/workflows/`
+   - `internal/config/workflows.go`
+   - `internal/config/temporal*.go`
+   - `sdk/workflows/`
+   - the affected task queue, worker registration, and Activity registration
+2. Keep Workflow Definitions deterministic:
+   - For the same Event History, workflow code must emit the same Commands in the same order when
+     it replays.
+   - Do not branch on wall-clock time, randomness, process-local state, env var reads, network
+     results, or unordered map iteration in workflow code.
+   - In Go workflow code, use replay-safe Temporal APIs such as `workflow.Go`,
+     `workflow.Channel`, `workflow.Selector`, `workflow.Now`, `workflow.Sleep`, and
+     `workflow.GetLogger` instead of native goroutines, channels, `select`, `time.Now`,
+     `time.Sleep`, or standard blocking primitives.
+3. Keep side effects out of workflow code:
+   - Do not perform direct network, filesystem, database, subprocess, or provider SDK I/O in
+     Workflow Definitions.
+   - Put external I/O, mutable side effects, and fallible business logic in Activities.
+   - Do not hide side effects behind helper functions called from workflow code.
+4. Design Activities for retries:
+   - Make Activities idempotent when they can retry. Use idempotency keys or duplicate detection
+     when the external system supports them.
+   - If an Activity cannot be retried safely, make that explicit in retry policy or error
+     handling.
+   - Split multi-step side effects at retry-safe boundaries so retries do not repeat completed
+     external effects blindly.
+   - For long-running work, heartbeat and persist enough progress or checkpoint detail to resume or
+     fail cleanly.
+5. Use local activities sparingly and with the same retry-safety discipline:
+   - Keep them short, low-latency, and free of long blocking calls.
+   - Treat them as worker-local helpers, not a place to hide slow or durable external
+     orchestration.
+   - In Go, prefer stable named functions over anonymous local-activity functions when that keeps
+     registration, histories, and diagnostics clearer.
+6. Use `SideEffect` and `MutableSideEffect` only for replay-safe value capture:
+   - The callback should return a value and must not mutate Workflow state.
+   - Do not put business logic, blocking work, or external I/O there.
+   - Prefer Activities when the value comes from outside the workflow process.
+7. Keep message handlers safe:
+   - Query handlers are read-only and must not mutate state or run async work.
+   - Signal and Update handlers should stay lightweight, coordinate with main-workflow state, and
+     avoid starting work the main workflow cannot account for safely.
+   - Do not call `Continue-As-New` from Signal or Update handlers.
+   - Before completion or `Continue-As-New`, finish critical in-flight handlers and drain or
+     account for pending Signals. Use `workflow.AllHandlersFinished` when handler completion
+     is part of the workflow's safety boundary.
+   - Prefer serializable request and response structs for handler inputs so interfaces can evolve
+     additively.
+8. Manage history and long-running executions deliberately:
+   - Watch Event History growth for loops, polling patterns, and message-heavy workflows.
+   - Use `Continue-As-New` before history becomes operationally risky.
+   - Carry forward enough workflow state in the next run input to resume safely.
+9. Treat workflow code changes as compatibility-sensitive:
+   - Reordering, adding, or removing command-producing calls for live executions needs Worker
+     Versioning or patching.
+   - This includes timers, Activities, local activities, Child Workflows, external signals,
+     `SideEffect` or `MutableSideEffect`, Search Attribute or Memo upserts, and
+     `Continue-As-New`.
+   - Prefer Worker Versioning for incompatible changes. Use patching when you must bridge old and
+     new histories in code.
+   - Plan rollout around running executions, not just fresh starts.
+10. Verify Temporal changes with replay in mind:
+   - Add or update the nearest unit or integration tests for the changed workflow or activity
+     surface.
+   - For Go Workflow Definition or message-handler changes, run `workflowcheck` when available
+     through repo-local or ephemeral tooling.
+   - Run replay tests against representative histories when practical, especially before shipping
+     changes that may replay on existing executions.
+   - If verification or rollout safety depends on external Temporal state you could not inspect,
+     say so plainly.
+
+## Anti-Patterns To Reject
+
+- direct I/O or side effects in Workflow Definitions
+- native Go goroutines, channels, `select`, `time.Now`, `time.Sleep`, or unordered map iteration
+  in workflow code
+- workflow branches on process-local or wall-clock state that is not recorded in history
+- mutating Workflow state inside `SideEffect` or `MutableSideEffect`
+- non-idempotent Activities that may grant, revoke, provision, charge, or notify twice on retry
+- long or unreliable work hidden in local activities
+- `Continue-As-New` or completion while important Signal or Update handler work is still in flight
+- incompatible command-sequence changes without Worker Versioning or patching
+- shipping workflow-definition changes based only on happy-path unit tests when replay validation
+  is feasible
+
+## Completion Criteria
+
+- Workflow code remains deterministic and side-effect free.
+- Activity boundaries and retry policy are explicit and safe for the external systems involved.
+- Message-handler, `Continue-As-New`, and versioning behavior are reviewed when applicable.
+- Replay-oriented verification and rollout risks are documented, run, or explicitly deferred.
+

--- a/.claude/skills/verify-change.md
+++ b/.claude/skills/verify-change.md
@@ -1,0 +1,32 @@
+> Generated from `.agent-shared/skills/verify-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+
+# Verify Change
+
+Use this skill after making a change, or earlier when you need to choose the right verification scope for the affected subsystem.
+
+## Required Inputs
+
+- Changed paths or packages
+- Whether Docker, Chromium, Ruby/Bundler, `swag`, and `flatc` are available
+- Whether the change is internal-only or user-facing
+
+## Steps
+
+1. Run `gofmt -w` on every changed Go file.
+2. Run root-module tests for code in the main module. Start with the narrowest useful package tests; use `go test ./...` when the change crosses packages or you need broader confidence.
+3. If the change affects behavior covered by the nested `test/` module, run the matching suite:
+   - Functional provider behavior: `cd test && go test -v -timeout 10m ./functional/...`
+   - Services/Temporal wiring: `cd test && go test -v -timeout 5m ./integration/services/...`
+   - Workflow behavior: `cd test && go test -v -timeout 15m ./integration/workflows/...`
+   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
+4. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll build`.
+5. If the change affects API annotations or generated Swagger assets, run `make swagger`.
+6. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
+7. Record every command you ran and call out anything you intentionally skipped.
+
+## Completion Criteria
+
+- Changed Go files are formatted.
+- Relevant tests/builds have been run, or skipped with a concrete reason.
+- Any required generated artifacts have been refreshed.
+

--- a/.claude/skills/verify-change.md
+++ b/.claude/skills/verify-change.md
@@ -1,8 +1,11 @@
-> Generated from `.agent-shared/skills/verify-change.md`. Edit the shared source and run `scripts/sync-agent-skills.sh`.
+> Generated from:
+> `.agent-shared/skills/verify-change.md`
+> Edit the shared source and run `scripts/sync-agent-skills.sh`.
 
 # Verify Change
 
-Use this skill after making a change, or earlier when you need to choose the right verification scope for the affected subsystem.
+Use this skill after making a change, or earlier when you need to choose the right verification
+scope for the affected subsystem.
 
 ## Required Inputs
 
@@ -12,21 +15,32 @@ Use this skill after making a change, or earlier when you need to choose the rig
 
 ## Steps
 
-1. Run `gofmt -w` on every changed Go file.
-2. Run root-module tests for code in the main module. Start with the narrowest useful package tests; use `go test ./...` when the change crosses packages or you need broader confidence.
-3. If the change affects behavior covered by the nested `test/` module, run the matching suite:
+1. Prefer TDD-style verification when practical: add or update a failing test first, confirm it
+   fails on the pre-change behavior, then implement the fix and rerun the targeted tests to confirm
+   they pass.
+2. Run `gofmt -w` on every changed Go file.
+3. Run root-module tests for code in the main module. Start with the narrowest useful package
+   tests; use `go test ./...` when the change crosses packages or you need broader confidence.
+4. If the change affects behavior covered by the nested `test/` module, run the matching suite:
    - Functional provider behavior: `cd test && go test -v -timeout 10m ./functional/...`
    - Services/Temporal wiring: `cd test && go test -v -timeout 5m ./integration/services/...`
    - Workflow behavior: `cd test && go test -v -timeout 15m ./integration/workflows/...`
-   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
-4. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll build`.
-5. If the change affects API annotations or generated Swagger assets, run `make swagger`.
-6. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
-7. Record every command you ran and call out anything you intentionally skipped.
+   - Frontend/browser flow: `make build-linux-amd64` then `cd test && go test -v -timeout 30m
+     ./integration/frontend/...`
+5. If the change touches Go Workflow Definitions or message handlers, use
+   `temporal-development` to scope determinism checks, including replay testing and
+   `workflowcheck` when practical.
+6. If the change affects docs-site content or navigation, run `cd docs && bundle exec jekyll
+   build`.
+7. If the change affects API annotations or generated Swagger assets, run `make swagger`.
+8. If the change affects FlatBuffers schemas or IAM dataset generation, run `make generate-data`.
+9. Record every command you ran and call out anything you intentionally skipped.
 
 ## Completion Criteria
 
 - Changed Go files are formatted.
 - Relevant tests/builds have been run, or skipped with a concrete reason.
+- Temporal determinism checks from `temporal-development` were included for Workflow-definition
+  changes, or explicitly deferred.
 - Any required generated artifacts have been refreshed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# Thand Agent Repository Guide
+
+This repository contains the Thand CLI, local agent, and server runtime for just-in-time access management. It is a Go codebase with a separate nested `test/` module for heavier functional and integration suites, plus a Jekyll docs site under `docs/`.
+
+## Architecture Snapshot
+
+- Entry point: `main.go` -> `cmd/cli/`
+- CLI commands and local agent startup: `cmd/cli/`
+- Server and HTTP API handling: `internal/daemon/`, `internal/api/`
+- Config loading, environment wiring, provider/role/workflow registration: `internal/config/`
+- Provider integrations and RBAC logic: `internal/providers/<provider>/`
+- Workflow orchestration and DSL/runtime helpers: `internal/workflows/`, `sdk/workflows/`
+- Shared SDK types and constants: `sdk/`
+- Public examples and default config: `config.example.yaml`, `examples/`
+- Heavy test suites: `test/functional/`, `test/integration/`
+- Public docs and API docs: `docs/`
+
+## First Pass In A Task
+
+Start by reading the files that define the repo's behavior instead of guessing:
+
+1. `README.md`
+2. `Makefile`
+3. `config.example.yaml`
+4. `.github/workflows/test-and-build.yml`
+5. The nearest package README or docs page for the subsystem you are touching
+
+If the task is not obviously local to one package, use the `repo-orientation` skill before editing.
+
+## Working Norms
+
+- Only one agent should mutate this checkout at a time. If parallel implementation is needed, use separate git worktrees.
+- Do not run side-effecting git commands concurrently in the same checkout. Inspect repo state first and stop if the repo is mid-merge, mid-rebase, or otherwise conflicted.
+- Keep changes architecture-aware: config loading belongs in `internal/config`, provider behavior in `internal/providers/<provider>`, workflow runtime behavior in `internal/workflows`, and user-facing command behavior in `cmd/cli`.
+- Preserve the existing provider pattern when adding or extending a provider: capability/schema/registration plus RBAC, session, and test coverage where applicable.
+- Treat `examples/`, `config.example.yaml`, and `docs/` as part of the product. Keep them in sync with user-facing behavior.
+- `third_party/iam-dataset` is a submodule used by data-generation flows. Do not update submodules unless the task actually requires it.
+- Do not commit secrets, tokens, generated local env files, or machine-specific absolute paths.
+- Prefer the repo's documented commands and workflows over ad hoc setup. In practice that means starting from `Makefile`, `README.md`, `docs/README.md`, and `RELEASE.md`.
+- Prefer small, reviewable changes. Split release/versioning work from feature work.
+
+## Verification Expectations
+
+There is no dedicated repo lint target today. Default to `gofmt` plus the smallest relevant test commands that match CI behavior.
+
+- Format changed Go files with `gofmt -w`.
+- Root Go module verification: `go test ./...`
+- Functional tests: `cd test && go test -v -timeout 10m ./functional/...`
+- Services integration: `cd test && go test -v -timeout 5m ./integration/services/...`
+- Workflow integration: `cd test && go test -v -timeout 15m ./integration/workflows/...`
+- Frontend E2E: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
+- Docs site: `cd docs && bundle exec jekyll build`
+- Swagger/API artifacts after API annotation changes: `make swagger`
+- FlatBuffers/IAM dataset regeneration only when schema or generator inputs change: `make generate-data`
+
+Notes:
+
+- CI uses Go `1.26` and `GOEXPERIMENT=jsonv2`; match that when reproducing build or release behavior.
+- Frontend, functional, and many integration tests depend on Docker/testcontainers. Frontend E2E also expects Chromium on Linux in CI.
+- The `test/` directory is its own Go module. Root `go test ./...` does not replace the nested `test/` suites.
+
+If you cannot run an expected suite, say exactly which command was skipped and why.
+
+## Risk And Review
+
+This repo handles privileged access. Treat the following as high-risk surfaces:
+
+- auth, login, and session state
+- provider grant/revoke logic
+- role/workflow resolution
+- Temporal configuration, worker registration, and retry/idempotency boundaries
+- service install/update flows
+- config loading, env var overrides, and secret handling
+- public API or CLI behavior
+
+For high-risk changes:
+
+- review both grant and revoke paths, not just the happy path
+- check least-privilege impact and audit/logging coverage
+- avoid leaking credentials or sensitive data in logs, examples, docs, or tests
+- verify failure and retry behavior, especially around Temporal activities/workflows
+- use `.github/PULL_REQUEST_TEMPLATE.md` as a practical review checklist
+
+If the task is a review or security-sensitive implementation, use the `risky-access-change-review` skill.
+
+## Definition Of Done
+
+A normal change is done when:
+
+1. The code and nearby tests are updated coherently.
+2. Relevant examples, docs, config, or generated artifacts are updated when public behavior changed.
+3. The smallest meaningful verification commands have been run.
+4. Any skipped verification is called out explicitly.
+5. No debug-only code, secrets, or temporary workarounds remain.
+
+## Repo-Local Skills
+
+Use skills for multi-step procedures instead of expanding this file:
+
+- `repo-orientation`
+- `verify-change`
+- `provider-or-workflow-change`
+- `public-surface-change`
+- `risky-access-change-review`
+
+Canonical skill sources live in `.agent-shared/skills/`. If you update shared skill text, run `scripts/sync-agent-skills.sh` to refresh the generated Codex and Claude copies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Thand Agent Repository Guide
 
-This repository contains the Thand CLI, local agent, and server runtime for just-in-time access management. It is a Go codebase with a separate nested `test/` module for heavier functional and integration suites, plus a Jekyll docs site under `docs/`.
+This repository contains the Thand CLI, local agent, and server runtime for just-in-time access
+management. It is a Go codebase with a separate nested `test/` module for heavier functional and
+integration suites, plus a Jekyll docs site under `docs/`.
 
 ## Architecture Snapshot
 
@@ -29,37 +31,72 @@ If the task is not obviously local to one package, use the `repo-orientation` sk
 
 ## Working Norms
 
-- Only one agent should mutate this checkout at a time. If parallel implementation is needed, use separate git worktrees.
-- Do not run side-effecting git commands concurrently in the same checkout. Inspect repo state first and stop if the repo is mid-merge, mid-rebase, or otherwise conflicted.
-- Keep changes architecture-aware: config loading belongs in `internal/config`, provider behavior in `internal/providers/<provider>`, workflow runtime behavior in `internal/workflows`, and user-facing command behavior in `cmd/cli`.
-- Preserve the existing provider pattern when adding or extending a provider: capability/schema/registration plus RBAC, session, and test coverage where applicable.
-- Treat `examples/`, `config.example.yaml`, and `docs/` as part of the product. Keep them in sync with user-facing behavior.
-- `third_party/iam-dataset` is a submodule used by data-generation flows. Do not update submodules unless the task actually requires it.
-- Do not commit secrets, tokens, generated local env files, or machine-specific absolute paths.
-- Prefer the repo's documented commands and workflows over ad hoc setup. In practice that means starting from `Makefile`, `README.md`, `docs/README.md`, and `RELEASE.md`.
+- Keep changes architecture-aware: config loading belongs in `internal/config`, provider behavior
+  in `internal/providers/<provider>`, workflow runtime behavior in `internal/workflows`, and
+  user-facing command behavior in `cmd/cli`.
+- Preserve the existing provider pattern when adding or extending a provider:
+  capability/schema/registration plus RBAC, session, and test coverage where applicable.
+- Treat `examples/`, `config.example.yaml`, and `docs/` as part of the product. Keep them in sync
+  with user-facing behavior.
+- `third_party/iam-dataset` is a submodule used by data-generation flows. Do not update submodules
+  unless the task actually requires it.
 - Prefer small, reviewable changes. Split release/versioning work from feature work.
+
+## Environment And Safety
+
+- Prefer TDD-style verification for code changes when practical: add or update a failing test
+  first, confirm it fails on the pre-change behavior, then implement the fix and rerun the targeted
+  tests to confirm they pass.
+- Do not install project-specific tools globally on the host.
+- Prefer the documented workspace scripts and wiring in `docs/development/index.md` and the repo's
+  documented commands in `Makefile`, `README.md`, `docs/README.md`, and `RELEASE.md` over ad hoc
+  environment setup.
+- Keep generated environment files out of tracked repos unless they are intentional workspace
+  assets.
+- Prefer symlinks, mounts and editable installs over copying code between repos.
+
+## Path Safety
+
+- Never commit absolute paths that point into a user's home directory or other non-standard
+  machine-local paths.
+- For committed file references, prefer repo-relative paths whenever possible.
+
+## Temporal Development
+
+- Use the `temporal-development` skill for Temporal Workflow Definitions, Activities, local
+  activities, message handlers, versioning, and replay-sensitive changes.
+- Keep Workflow Definitions deterministic and side-effect free, keep external I/O in Activities,
+  and treat replay compatibility as a rollout concern instead of a local refactor.
+- For security-sensitive or privileged-access workflow changes, use
+  `risky-access-change-review` alongside `temporal-development`.
 
 ## Verification Expectations
 
-There is no dedicated repo lint target today. Default to `gofmt` plus the smallest relevant test commands that match CI behavior.
+There is no dedicated repo lint target today. Default to `gofmt` plus the smallest relevant test
+commands that match CI behavior.
 
 - Format changed Go files with `gofmt -w`.
 - Root Go module verification: `go test ./...`
 - Functional tests: `cd test && go test -v -timeout 10m ./functional/...`
 - Services integration: `cd test && go test -v -timeout 5m ./integration/services/...`
 - Workflow integration: `cd test && go test -v -timeout 15m ./integration/workflows/...`
-- Frontend E2E: `make build-linux-amd64` then `cd test && go test -v -timeout 30m ./integration/frontend/...`
+- Frontend E2E: `make build-linux-amd64` then `cd test && go test -v -timeout 30m
+  ./integration/frontend/...`
 - Docs site: `cd docs && bundle exec jekyll build`
 - Swagger/API artifacts after API annotation changes: `make swagger`
-- FlatBuffers/IAM dataset regeneration only when schema or generator inputs change: `make generate-data`
+- FlatBuffers/IAM dataset regeneration only when schema or generator inputs change: `make
+  generate-data`
 
 Notes:
 
-- CI uses Go `1.26` and `GOEXPERIMENT=jsonv2`; match that when reproducing build or release behavior.
-- Frontend, functional, and many integration tests depend on Docker/testcontainers. Frontend E2E also expects Chromium on Linux in CI.
-- The `test/` directory is its own Go module. Root `go test ./...` does not replace the nested `test/` suites.
-
-If you cannot run an expected suite, say exactly which command was skipped and why.
+- CI uses Go `1.26` and `GOEXPERIMENT=jsonv2`; match that when reproducing build or release
+  behavior.
+- Frontend, functional, and many integration tests depend on Docker/testcontainers. Frontend E2E
+  also expects Chromium on Linux in CI.
+- The `test/` directory is its own Go module. Root `go test ./...` does not replace the nested
+  `test/` suites.
+- If a change touches Temporal Workflow Definitions or message handlers, add replay testing and
+  `workflowcheck` to the verification plan when practical, and say plainly if either was skipped.
 
 ## Risk And Review
 
@@ -81,14 +118,16 @@ For high-risk changes:
 - verify failure and retry behavior, especially around Temporal activities/workflows
 - use `.github/PULL_REQUEST_TEMPLATE.md` as a practical review checklist
 
-If the task is a review or security-sensitive implementation, use the `risky-access-change-review` skill.
+If the task is a review or security-sensitive implementation, use the `risky-access-change-review`
+skill.
 
 ## Definition Of Done
 
 A normal change is done when:
 
 1. The code and nearby tests are updated coherently.
-2. Relevant examples, docs, config, or generated artifacts are updated when public behavior changed.
+2. Relevant examples, docs, config, or generated artifacts are updated when public behavior
+   changed.
 3. The smallest meaningful verification commands have been run.
 4. Any skipped verification is called out explicitly.
 5. No debug-only code, secrets, or temporary workarounds remain.
@@ -102,5 +141,7 @@ Use skills for multi-step procedures instead of expanding this file:
 - `provider-or-workflow-change`
 - `public-surface-change`
 - `risky-access-change-review`
+- `temporal-development`
 
-Canonical skill sources live in `.agent-shared/skills/`. If you update shared skill text, run `scripts/sync-agent-skills.sh` to refresh the generated Codex and Claude copies.
+Canonical skill sources live in `.agent-shared/skills/`. If you update shared skill text, run
+`scripts/sync-agent-skills.sh` to refresh the generated Codex and Claude copies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Notes
+
+`AGENTS.md` is the canonical repository policy for this repo. Read it first and treat it as the shared source of truth with Codex.
+
+Repo-local skills for Claude live under `.claude/skills/` and are generated from the shared sources in `.agent-shared/skills/`. If skill content changes, update the shared source and run `scripts/sync-agent-skills.sh`.
+
+No additional Claude-specific workflow rules are needed right now.

--- a/scripts/sync-agent-skills.sh
+++ b/scripts/sync-agent-skills.sh
@@ -21,13 +21,17 @@ for src in "$shared_dir"/*.md; do
   mkdir -p "$codex_skill_dir"
 
   {
-    printf '> Generated from `%s`. Edit the shared source and run `scripts/sync-agent-skills.sh`.\n\n' "$source_ref"
+    printf '> Generated from:\n'
+    printf '> `%s`\n' "$source_ref"
+    printf '> Edit the shared source and run `scripts/sync-agent-skills.sh`.\n\n'
     cat "$src"
     printf '\n'
   } > "$codex_out"
 
   {
-    printf '> Generated from `%s`. Edit the shared source and run `scripts/sync-agent-skills.sh`.\n\n' "$source_ref"
+    printf '> Generated from:\n'
+    printf '> `%s`\n' "$source_ref"
+    printf '> Edit the shared source and run `scripts/sync-agent-skills.sh`.\n\n'
     cat "$src"
     printf '\n'
   } > "$claude_out"

--- a/scripts/sync-agent-skills.sh
+++ b/scripts/sync-agent-skills.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+shared_dir="$repo_root/.agent-shared/skills"
+codex_dir="$repo_root/.agents/skills"
+claude_dir="$repo_root/.claude/skills"
+
+mkdir -p "$codex_dir" "$claude_dir"
+
+for src in "$shared_dir"/*.md; do
+  [ -e "$src" ] || continue
+
+  name="$(basename "$src" .md)"
+  codex_skill_dir="$codex_dir/$name"
+  codex_out="$codex_skill_dir/SKILL.md"
+  claude_out="$claude_dir/$name.md"
+  source_ref=".agent-shared/skills/$name.md"
+
+  mkdir -p "$codex_skill_dir"
+
+  {
+    printf '> Generated from `%s`. Edit the shared source and run `scripts/sync-agent-skills.sh`.\n\n' "$source_ref"
+    cat "$src"
+    printf '\n'
+  } > "$codex_out"
+
+  {
+    printf '> Generated from `%s`. Edit the shared source and run `scripts/sync-agent-skills.sh`.\n\n' "$source_ref"
+    cat "$src"
+    printf '\n'
+  } > "$claude_out"
+done


### PR DESCRIPTION
## Summary
- add repo-local agent policy guidance in `AGENTS.md` and the shared/generated agent skills
- add Temporal development guardrails covering determinism, side effects, idempotency, retry safety, and Worker Versioning or patching
- keep generated Codex and Claude skill files in sync and wrap generated headers for readability

## Verification
- ran `./scripts/sync-agent-skills.sh`
- verified the updated policy and generated Markdown files are under 100 columns
- did not run Go, docs-site, or integration test suites because this change is policy text only
