### PR TITLE
fix(workflows): deterministic notifier task ordering

### DIFF
--- a/internal/workflows/tasks/providers/thand/approvals.go
+++ b/internal/workflows/tasks/providers/thand/approvals.go
@@ -3,7 +3,8 @@ package thand
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -435,13 +436,7 @@ func (t *thandTask) makeApprovalNotifications(
 	// In parallel create a notifier for each of the notifiers
 	// Build notification tasks for each provider
 	var notifyTasks []notifyTask
-	providerKeys := make([]string, 0, len(approvalsTask.Notifiers))
-	for providerKey := range approvalsTask.Notifiers {
-		providerKeys = append(providerKeys, providerKey)
-	}
-	sort.Strings(providerKeys)
-
-	for _, providerKey := range providerKeys {
+	for _, providerKey := range slices.Sorted(maps.Keys(approvalsTask.Notifiers)) {
 		notifierRequest := approvalsTask.Notifiers[providerKey]
 		// Create an ApprovalNotifier for each provider
 		approvalNotifier := NewApprovalsNotifier(
@@ -554,13 +549,7 @@ func (t *thandTask) notifyApprovalRejection(
 	}
 
 	// Send rejection notification using each configured notifier
-	providerKeys := make([]string, 0, len(approvalsTask.Notifiers))
-	for providerKey := range approvalsTask.Notifiers {
-		providerKeys = append(providerKeys, providerKey)
-	}
-	sort.Strings(providerKeys)
-
-	for _, providerKey := range providerKeys {
+	for _, providerKey := range slices.Sorted(maps.Keys(approvalsTask.Notifiers)) {
 		notifierRequest := approvalsTask.Notifiers[providerKey]
 		// Create a generic notifier for rejection with the approver as recipient
 		rejectionRequest := thandFunction.NotifierRequest{

--- a/internal/workflows/tasks/providers/thand/approvals.go
+++ b/internal/workflows/tasks/providers/thand/approvals.go
@@ -3,6 +3,7 @@ package thand
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -434,7 +435,14 @@ func (t *thandTask) makeApprovalNotifications(
 	// In parallel create a notifier for each of the notifiers
 	// Build notification tasks for each provider
 	var notifyTasks []notifyTask
-	for providerKey, notifierRequest := range approvalsTask.Notifiers {
+	providerKeys := make([]string, 0, len(approvalsTask.Notifiers))
+	for providerKey := range approvalsTask.Notifiers {
+		providerKeys = append(providerKeys, providerKey)
+	}
+	sort.Strings(providerKeys)
+
+	for _, providerKey := range providerKeys {
+		notifierRequest := approvalsTask.Notifiers[providerKey]
 		// Create an ApprovalNotifier for each provider
 		approvalNotifier := NewApprovalsNotifier(
 			t.config,
@@ -546,7 +554,14 @@ func (t *thandTask) notifyApprovalRejection(
 	}
 
 	// Send rejection notification using each configured notifier
-	for providerKey, notifierRequest := range approvalsTask.Notifiers {
+	providerKeys := make([]string, 0, len(approvalsTask.Notifiers))
+	for providerKey := range approvalsTask.Notifiers {
+		providerKeys = append(providerKeys, providerKey)
+	}
+	sort.Strings(providerKeys)
+
+	for _, providerKey := range providerKeys {
+		notifierRequest := approvalsTask.Notifiers[providerKey]
 		// Create a generic notifier for rejection with the approver as recipient
 		rejectionRequest := thandFunction.NotifierRequest{
 			Provider: notifierRequest.Provider,

--- a/internal/workflows/tasks/providers/thand/authorize.go
+++ b/internal/workflows/tasks/providers/thand/authorize.go
@@ -3,8 +3,9 @@ package thand
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -557,13 +558,7 @@ func (t *thandTask) makeAuthorizationNotifications(
 
 	// Build notification tasks for each provider
 	var notifyTasks []notifyTask
-	providerKeys := make([]string, 0, len(authorizeTask.Notifiers))
-	for providerKey := range authorizeTask.Notifiers {
-		providerKeys = append(providerKeys, providerKey)
-	}
-	sort.Strings(providerKeys)
-
-	for _, providerKey := range providerKeys {
+	for _, providerKey := range slices.Sorted(maps.Keys(authorizeTask.Notifiers)) {
 		notifierRequest := authorizeTask.Notifiers[providerKey]
 		// Create an AuthorizerNotifier for each provider
 		authorizeNotifier := NewAuthorizerNotifier(

--- a/internal/workflows/tasks/providers/thand/authorize.go
+++ b/internal/workflows/tasks/providers/thand/authorize.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -556,7 +557,14 @@ func (t *thandTask) makeAuthorizationNotifications(
 
 	// Build notification tasks for each provider
 	var notifyTasks []notifyTask
-	for providerKey, notifierRequest := range authorizeTask.Notifiers {
+	providerKeys := make([]string, 0, len(authorizeTask.Notifiers))
+	for providerKey := range authorizeTask.Notifiers {
+		providerKeys = append(providerKeys, providerKey)
+	}
+	sort.Strings(providerKeys)
+
+	for _, providerKey := range providerKeys {
+		notifierRequest := authorizeTask.Notifiers[providerKey]
 		// Create an AuthorizerNotifier for each provider
 		authorizeNotifier := NewAuthorizerNotifier(
 			t.config,

--- a/internal/workflows/tasks/providers/thand/form.go
+++ b/internal/workflows/tasks/providers/thand/form.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/serverlessworkflow/sdk-go/v3/model"
@@ -248,7 +249,14 @@ func (t *thandTask) makeFormNotifications(
 
 	var notifyTasks []notifyTask
 
-	for providerKey, notifierRequest := range formTask.Notifiers {
+	providerKeys := make([]string, 0, len(formTask.Notifiers))
+	for providerKey := range formTask.Notifiers {
+		providerKeys = append(providerKeys, providerKey)
+	}
+	sort.Strings(providerKeys)
+
+	for _, providerKey := range providerKeys {
+		notifierRequest := formTask.Notifiers[providerKey]
 		// Create a FormNotifier for each provider
 		formNotifier := NewFormNotifier(
 			t.config,

--- a/internal/workflows/tasks/providers/thand/form.go
+++ b/internal/workflows/tasks/providers/thand/form.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/serverlessworkflow/sdk-go/v3/model"
@@ -249,13 +250,7 @@ func (t *thandTask) makeFormNotifications(
 
 	var notifyTasks []notifyTask
 
-	providerKeys := make([]string, 0, len(formTask.Notifiers))
-	for providerKey := range formTask.Notifiers {
-		providerKeys = append(providerKeys, providerKey)
-	}
-	sort.Strings(providerKeys)
-
-	for _, providerKey := range providerKeys {
+	for _, providerKey := range slices.Sorted(maps.Keys(formTask.Notifiers)) {
 		notifierRequest := formTask.Notifiers[providerKey]
 		// Create a FormNotifier for each provider
 		formNotifier := NewFormNotifier(

--- a/internal/workflows/tasks/providers/thand/revoke.go
+++ b/internal/workflows/tasks/providers/thand/revoke.go
@@ -3,7 +3,8 @@ package thand
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -366,13 +367,7 @@ func (t *thandTask) makeRevocationNotifications(
 
 	// Build notification tasks for each provider
 	var notifyTasks []notifyTask
-	providerKeys := make([]string, 0, len(revokeTask.Notifiers))
-	for providerKey := range revokeTask.Notifiers {
-		providerKeys = append(providerKeys, providerKey)
-	}
-	sort.Strings(providerKeys)
-
-	for _, providerKey := range providerKeys {
+	for _, providerKey := range slices.Sorted(maps.Keys(revokeTask.Notifiers)) {
 		notifierRequest := revokeTask.Notifiers[providerKey]
 		// Create a RevokeNotifier for each provider
 		revokeNotifier := NewRevokeNotifier(

--- a/internal/workflows/tasks/providers/thand/revoke.go
+++ b/internal/workflows/tasks/providers/thand/revoke.go
@@ -3,6 +3,7 @@ package thand
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -365,7 +366,14 @@ func (t *thandTask) makeRevocationNotifications(
 
 	// Build notification tasks for each provider
 	var notifyTasks []notifyTask
-	for providerKey, notifierRequest := range revokeTask.Notifiers {
+	providerKeys := make([]string, 0, len(revokeTask.Notifiers))
+	for providerKey := range revokeTask.Notifiers {
+		providerKeys = append(providerKeys, providerKey)
+	}
+	sort.Strings(providerKeys)
+
+	for _, providerKey := range providerKeys {
+		notifierRequest := revokeTask.Notifiers[providerKey]
 		// Create a RevokeNotifier for each provider
 		revokeNotifier := NewRevokeNotifier(
 			t.config,


### PR DESCRIPTION
## Summary
- make notifier provider iteration deterministic in workflow-capable notification paths
- sort notifier map keys before building/scheduling notification tasks
- apply consistently across authorize, revoke, approvals, and form paths

## Why
Go map iteration order is randomized. These notification tasks are later scheduled via workflow goroutines, so non-deterministic iteration can reorder scheduled activities between runs.

## Changes
- internal/workflows/tasks/providers/thand/authorize.go
- internal/workflows/tasks/providers/thand/revoke.go
- internal/workflows/tasks/providers/thand/approvals.go
- internal/workflows/tasks/providers/thand/form.go

## Validation
- gofmt -w on touched files
- go test -mod=mod ./internal/workflows/tasks/providers/thand -run TestDoesNotExist
